### PR TITLE
Exit non-zero on command error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,8 @@ extern crate log;
 
 #[tokio::main]
 async fn main() {
-    match cli::execute().await {
-        Ok(_) => {}
-        Err(err) => println!("Error: {err:?}"),
+    if let Err(err) = cli::execute().await {
+        eprintln!("Error: {err:?}");
+        std::process::exit(1);
     }
 }

--- a/tests/exit_code.rs
+++ b/tests/exit_code.rs
@@ -1,0 +1,25 @@
+use std::process::Command;
+
+/// The CLI must exit with a non-zero status when a command fails, so that
+/// callers (shell scripts, cron, docker-compose) can detect failures.
+///
+/// We trigger a deterministic, offline error by importing a file that does not
+/// exist. `APP_DATA_PATH`/`APP_BUILD_PATH` are pointed at a temp dir so the run
+/// leaves nothing behind in the repo.
+#[test]
+fn exits_nonzero_when_command_fails() {
+    let tmp = std::env::temp_dir().join("fossilizer-exit-code-test");
+
+    let status = Command::new(env!("CARGO_BIN_EXE_fossilizer"))
+        .env("APP_DATA_PATH", tmp.join("data"))
+        .env("APP_BUILD_PATH", tmp.join("build"))
+        .arg("import")
+        .arg("/nonexistent/definitely-not-a-real-export.tar.gz")
+        .status()
+        .expect("failed to run the fossilizer binary");
+
+    assert!(
+        !status.success(),
+        "expected a non-zero exit status when the command fails, got {status:?}"
+    );
+}


### PR DESCRIPTION
## Problem

`src/main.rs` matched on `cli::execute()`'s `Result` and, on `Err`, printed the error but never set a non-zero exit code:

```rust
match cli::execute().await {
    Ok(_) => {}
    Err(err) => println!("Error: {err:?}"),
}
```

So **every** command exited 0 even on failure, and errors went to **stdout**. Any caller that checks exit status (shell scripts, cron, `docker compose`, CI) could not detect failures. This surfaced in the Docker backup loop (#46): a dead Mastodon instance failed with a DNS error but exited 0, so the loop's graceful-failure warning never fired.

## Fix

```rust
if let Err(err) = cli::execute().await {
    eprintln!("Error: {err:?}");
    std::process::exit(1);
}
```

Propagates errors to stderr and exits 1 on failure.

## Test

Adds `tests/exit_code.rs` — an integration test that runs the built binary against a deterministic offline error (`import` of a nonexistent file, with data/build paths pointed at a temp dir) and asserts a non-zero exit. Verified it fails on the old code (exit 0) and passes with the fix.

`cargo fmt --check`, `cargo clippy --all-targets`, and the full test suite are clean.

Fixes #47