### PR TITLE
Code review: error-handling fixes, XSS/injection hardening, lint tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,26 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  # Fast lint gate - formatting and clippy on a single target
+  lint:
+    name: Lint (fmt + clippy)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - name: Cache cargo & target directories
+        uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "v0-rust"
+          shared-key: "lint"
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+      - name: Run clippy
+        run: cargo clippy --all-targets --locked -- -D warnings
+
   # Quick test for PRs - only Linux-x86_64
   test-pr:
     name: PR Quick Test - Linux-x86_64

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@ Settings.toml
 /build
 /data
 /.vscode
+# Local build/backup archives at repo root — guard against committing large blobs
+# (anchored to root so test fixtures under src/resources/test/ stay addable)
+/*.tgz
+/*.tar.gz
+/*.tar
+/*.zip

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+.PHONY: check fmt lint test build serve docs clean
+
+# Format + lint (matches what CI enforces)
+check: fmt lint
+
+fmt:
+	cargo fmt --all -- --check
+
+lint:
+	cargo clippy --all-targets --locked -- -D warnings
+
+test:
+	cargo test --locked
+
+build:
+	cargo build --release --locked
+
+# Serve the built site locally (run `make build` and `fossilizer build` first)
+serve:
+	cargo run -- serve --open
+
+docs:
+	./scripts/build-docs.sh
+
+clean:
+	cargo clean

--- a/docs/dev-sessions/2026-07-23-1456-code-review/notes.md
+++ b/docs/dev-sessions/2026-07-23-1456-code-review/notes.md
@@ -1,0 +1,54 @@
+# Code Review — 2026-07-23
+
+Thorough multi-agent code review of fossilizer (Rust Mastodon-export static-site generator, ~3200 LOC).
+
+**Baseline:** build ✅ · clippy clean ✅ · 11 tests pass ✅ · v0.5.0
+
+Reviewed in 6 parallel agent passes: CLI, Mastodon subsystem, DB, ActivityStreams/templates, site-gen/core, project hygiene/deps/CI.
+
+## Cross-cutting themes
+
+1. **Silent failure / exits-0** — CLI already fixed in unmerged branch `fix-cli-exit-code`. But many inner paths still `return Ok(())` on failure or swallow errors (maps to existing issue **#14 Improve error handling**).
+2. **Panics on untrusted data** — infallible `From` impls `.unwrap()` on export/API JSON & URIs; importer/db `.unwrap()`s. A malformed export/response crashes import/fetch/build.
+3. **Downloader robustness** — download failures silently discarded, no HTTP status check, no timeouts, new client per task, blocking IO in async.
+4. **Security** — zip-slip in tar extraction; `| safe` on remote-authored HTML; `innerHTML` from alt-text.
+5. **Dependency bloat** — dual reqwest 0.11+0.12 (→ dual hyper/http/rustls), openssl-vendored + rustls both compiled.
+6. **Testability** — global mutable config singleton blocks unit testing of site-gen.
+7. **Tooling gaps** — no Makefile, no clippy/fmt in CI, no cargo-audit.
+
+## Low-hanging fruit (fix in this session)
+- downloader: `.error_for_status()?` before writing body
+- config.rs `init()`: `.unwrap()` → `?` (2 sites)
+- db.rs `conn()`: `.unwrap()` → `?` (3 sites)
+- cli/build.rs: `.unwrap()` → `?` throughout
+- cli/serve.rs: parse/to_str `.unwrap()` → `?`/display
+- cli/mastodon/code.rs: remove access-token `println!` (secret leak)
+- importer: `import_zip` unwraps → `?`; unsupported extension → `Err`
+- instance.rs `register_client_app`: `Ok(())` on failure → `Err`
+- db/actors.rs `get_actors`: skip bad rows (warn) to match activities
+- templates.rs `filter_urlpath`: fix wrong error label + unwraps
+- activitystreams: `.or_else(|| Some()).unwrap()` → `unwrap_or_else`
+- db count `i16` → `i64`; drop meaningless `ORDER BY` in count
+- media-lightbox.js: `innerHTML` → `textContent`
+- .gitignore: add archive patterns (`*.tgz` etc.) as guardrail for stray 2.9GB tarball
+- Add Makefile (check/test/build/serve/docs)
+- Add CI fmt+clippy lint job
+
+## Larger concerns → GitHub issues (see issues.md for filed list)
+- Panics on untrusted data (TryFrom refactor)
+- Downloader robustness (errors/timeouts/streaming/shared client)
+- Zip-slip path traversal in tar extraction (security)
+- XSS: `| safe` on remote HTML + review escaping (security)
+- DB transaction leak (`import_many`/`import_collection` need RAII txn)
+- Dependency consolidation (reqwest 0.12, drop openssl)
+- Global config testability
+- Migration validation test + SQL double-quote-string convention
+- Temp media dir leak on failed import
+- Orphaned `src/cli/fetch.rs` (WIP for existing #12)
+
+## Notes / non-issues confirmed by agents
+- rarray() queries are injection-safe (bound params)
+- per-page db::conn() in rayon loop is intentional/correct
+- downloader Notify shutdown protocol is correct
+- pagefind/build/ are gitignored (not tracked) — only build-20251205.tgz is a risk
+- Cargo.toml versions are caret minimums; Cargo.lock resolves upward

--- a/docs/dev-sessions/2026-07-23-1456-code-review/notes.md
+++ b/docs/dev-sessions/2026-07-23-1456-code-review/notes.md
@@ -46,6 +46,28 @@ Reviewed in 6 parallel agent passes: CLI, Mastodon subsystem, DB, ActivityStream
 - Temp media dir leak on failed import
 - Orphaned `src/cli/fetch.rs` (WIP for existing #12)
 
+## GitHub issues filed
+- #49 Security: zip-slip path traversal in tar/gz import
+- #50 Security: sanitize/escape remote-authored HTML rendered with `| safe`
+- #51 Downloader: surface failures, timeouts, shared client, stream to disk
+- #52 Replace panicking `From` impls with `TryFrom` for untrusted data
+- #53 DB: RAII transactions in import paths
+- #54 Consolidate HTTP/TLS deps (reqwest 0.12, drop vendored openssl)
+- #55 Reduce reliance on global mutable config (testability)
+- #56 Migration validation test + single-quote SQL literals
+- #57 Fix remote-actor URL derivation for federated accounts
+- #58 Code-quality cleanup grab-bag (orphaned fetch.rs, no-op flags, temp-dir leak, docs, mime mapping, disabled template tests, cargo-audit)
+
+Existing issues cross-referenced: #14 (error handling), #12 (outbox fetch → orphaned cli/fetch.rs), #35 (fetch-before-link panic).
+
+## Fixes committed (this branch, worktree-code-review)
+1. `850cee9` Replace panics with error propagation; stop swallowing failures (12 files)
+2. `321d105` Render media descriptions as text (XSS)
+3. `6b8c106` Add Makefile, CI lint gate, archive gitignore guardrail
+4. `4b2313a` Session notes
+
+Not committed / flagged for Les: the stray ~2.9 GB `build-20251205.tgz` and `backup-toots.sh` at the repo root (untracked, live in the main checkout, not the worktree). `.gitignore` now guards against committing root archives; the tarball itself should be deleted/moved manually.
+
 ## Notes / non-issues confirmed by agents
 - rarray() queries are injection-safe (bound params)
 - per-page db::conn() in rayon loop is intentional/correct

--- a/src/activitystreams.rs
+++ b/src/activitystreams.rs
@@ -267,8 +267,7 @@ impl From<megalodon::entities::Status> for Activity {
                                 url: quoted_status
                                     .url
                                     .clone()
-                                    .or_else(|| Some(quoted_status.uri.clone()))
-                                    .unwrap(),
+                                    .unwrap_or_else(|| quoted_status.uri.clone()),
                                 type_field: "Note".to_string(),
                                 published: quoted_status.created_at,
                                 content: Some(quoted_status.content.clone()),
@@ -294,7 +293,7 @@ impl From<megalodon::entities::Status> for Activity {
 
             IdOrObject::Object(Object {
                 id: status.uri.clone(),
-                url: status.url.or_else(|| Some(status.uri.clone())).unwrap(),
+                url: status.url.unwrap_or_else(|| status.uri.clone()),
                 type_field: "Note".to_string(),
                 published: status.created_at,
                 content: Some(status.content),

--- a/src/activitystreams.rs
+++ b/src/activitystreams.rs
@@ -253,8 +253,8 @@ impl From<megalodon::entities::Status> for Activity {
         }
         .to_string();
 
-        let object = if status.reblog.is_some() {
-            IdOrObject::Id(status.reblog.unwrap().uri)
+        let object = if let Some(reblog) = status.reblog {
+            IdOrObject::Id(reblog.uri)
         } else {
             // Extract quote information if present
             let quote_object = status.quote.and_then(|quoted| {

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -33,8 +33,8 @@ pub async fn command(args: &BuildArgs) -> Result<(), Box<dyn Error>> {
     let skip_assets = args.skip_assets;
 
     config::update(|config| {
-        if args.theme.is_some() {
-            config.theme = args.theme.as_ref().unwrap().clone();
+        if let Some(theme) = &args.theme {
+            config.theme = theme.clone();
         }
     })?;
 
@@ -44,23 +44,23 @@ pub async fn command(args: &BuildArgs) -> Result<(), Box<dyn Error>> {
     site_generator::setup_build_path(&config.build_path, &clean)?;
 
     if !skip_assets {
-        site_generator::copy_web_assets(&config.build_path).unwrap();
+        site_generator::copy_web_assets(&config.build_path)?;
     }
 
     if !skip_activities || !skip_index || !skip_index_json {
-        let tera = templates::init().unwrap();
-        let db_conn = db::conn().unwrap();
+        let tera = templates::init()?;
+        let db_conn = db::conn()?;
         let db_activities = db::activities::Activities::new(&db_conn);
         let db_actors = db::actors::Actors::new(&db_conn);
 
-        let actors = db_actors.get_actors_by_id().unwrap();
+        let actors = db_actors.get_actors_by_id()?;
         let day_entries =
-            site_generator::plan_activities_pages(&config.build_path, &db_activities).unwrap();
+            site_generator::plan_activities_pages(&config.build_path, &db_activities)?;
         if !skip_index {
-            site_generator::generate_index_page(&config.build_path, &day_entries, &tera).unwrap();
+            site_generator::generate_index_page(&config.build_path, &day_entries, &tera)?;
         }
         if !skip_index_json {
-            site_generator::generate_index_json(&config.build_path, &day_entries).unwrap();
+            site_generator::generate_index_json(&config.build_path, &day_entries)?;
         }
         if !skip_activities {
             site_generator::generate_activities_pages(
@@ -68,8 +68,7 @@ pub async fn command(args: &BuildArgs) -> Result<(), Box<dyn Error>> {
                 &tera,
                 &actors,
                 &day_entries,
-            )
-            .unwrap();
+            )?;
         }
     }
 

--- a/src/cli/mastodon/code.rs
+++ b/src/cli/mastodon/code.rs
@@ -28,8 +28,9 @@ pub async fn command(
     let code = &args.code;
 
     if instance_config.client_id.is_none() {
-        // todo: throw an error if no client has been registered yet
-        return Ok(());
+        return Err(
+            format!("no client registered for {instance}; run `mastodon link` first").into(),
+        );
     }
 
     let mut params = HashMap::new();
@@ -45,18 +46,16 @@ pub async fn command(
     params.insert("client_secret", client_secret.as_str());
 
     let url = format!("https://{instance}/oauth/token");
-    let client = reqwest::ClientBuilder::new().build().unwrap();
+    let client = reqwest::Client::new();
     let res = client.post(url).json(&params).send().await?;
 
     if res.status() == reqwest::StatusCode::OK {
         let result: CodeAuthResult = res.json().await?;
         instance_config.access_token = Some(result.access_token);
         instance_config.created_at = Some(result.created_at);
-        println!("CODE {} {:?}", args.code, instance_config.access_token);
+        info!("Authorization successful for {instance}");
         Ok(())
     } else {
-        // todo: throw an error here
-        error!("Failed to authorize with code");
-        Ok(())
+        Err(format!("failed to authorize with code: {}", res.status()).into())
     }
 }

--- a/src/cli/mastodon/code.rs
+++ b/src/cli/mastodon/code.rs
@@ -27,22 +27,23 @@ pub async fn command(
     let instance = &parent_args.instance;
     let code = &args.code;
 
-    if instance_config.client_id.is_none() {
-        return Err(
-            format!("no client registered for {instance}; run `mastodon link` first").into(),
-        );
-    }
+    let not_registered =
+        || format!("no client registered for {instance}; run `mastodon link` first");
+    let client_id = instance_config
+        .client_id
+        .as_ref()
+        .ok_or_else(not_registered)?;
+    let client_secret = instance_config
+        .client_secret
+        .as_ref()
+        .ok_or_else(not_registered)?;
 
     let mut params = HashMap::new();
     params.insert("scopes", OAUTH_SCOPES);
     params.insert("redirect_uri", REDIRECT_URI_OOB);
     params.insert("grant_type", "authorization_code");
     params.insert("code", code);
-
-    let client_id = instance_config.client_id.as_ref().unwrap();
     params.insert("client_id", client_id.as_str());
-
-    let client_secret = instance_config.client_secret.as_ref().unwrap();
     params.insert("client_secret", client_secret.as_str());
 
     let url = format!("https://{instance}/oauth/token");

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -25,15 +25,13 @@ pub async fn command(args: &ServeArgs) -> Result<(), Box<dyn Error>> {
     let build_path = config.build_path;
 
     let addr = format!("{}:{}", args.host.clone(), args.port);
-    let addr: SocketAddr = addr.parse().unwrap();
+    let addr: SocketAddr = addr
+        .parse()
+        .map_err(|e| format!("invalid host/port {addr:?}: {e}"))?;
 
     let serving_url = format!("http://{}", addr);
 
-    info!(
-        "Serving up {} at {}",
-        build_path.to_str().unwrap(),
-        serving_url
-    );
+    info!("Serving up {} at {}", build_path.display(), serving_url);
 
     if open_browser {
         open(serving_url);

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,11 +72,11 @@ pub fn init(config_path: &Path) -> Result<(), Box<dyn Error>> {
     }
     config = config.add_source(config::Environment::with_prefix(ENV_PREFIX));
 
-    let config = config.build().unwrap();
+    let config = config.build()?;
 
     let mut context = CONTEXT.write()?;
     context.raw_config = config.clone();
-    context.config = config.try_deserialize().unwrap();
+    context.config = config.try_deserialize()?;
 
     Ok(())
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -32,11 +32,11 @@ pub fn conn() -> Result<Connection, Box<dyn Error>> {
 
     let database_path = config.database_path();
     let database_parent_path = Path::new(&database_path).parent().ok_or("no parent path")?;
-    fs::create_dir_all(database_parent_path).unwrap();
+    fs::create_dir_all(database_parent_path)?;
 
     let conn = Connection::open(&database_path)?;
-    conn.pragma_update(None, "journal_mode", "WAL").unwrap();
-    conn.pragma_update(None, "foreign_keys", "ON").unwrap();
+    conn.pragma_update(None, "journal_mode", "WAL")?;
+    conn.pragma_update(None, "foreign_keys", "ON")?;
 
     rusqlite::vtab::array::load_module(&conn)?;
 

--- a/src/db/activities.rs
+++ b/src/db/activities.rs
@@ -228,14 +228,13 @@ impl<'a> Activities<'a> {
         )
     }
 
-    pub fn count_activities_by_ids(&self, ids: &[String]) -> Result<i16> {
+    pub fn count_activities_by_ids(&self, ids: &[String]) -> Result<i64> {
         query_count(
             self.conn,
             r#"
                 SELECT COUNT(id)
                 FROM activities
                 WHERE id IN rarray(?1)
-                ORDER BY published ASC
             "#,
             [ids_to_rarray_param(ids)],
         )
@@ -263,7 +262,7 @@ where
     result
 }
 
-fn query_count<P>(conn: &Connection, sql: &str, params: P) -> Result<i16>
+fn query_count<P>(conn: &Connection, sql: &str, params: P) -> Result<i64>
 where
     P: rusqlite::Params,
 {

--- a/src/db/actors.rs
+++ b/src/db/actors.rs
@@ -44,8 +44,12 @@ impl<'a> Actors<'a> {
         let mut out = Vec::new();
         while let Some(r) = rows.next()? {
             let json_text: String = r.get(0)?;
-            let actor: T = serde_json::from_str(json_text.as_str())?;
-            out.push(actor);
+            // Skip (rather than abort on) actor rows that fail to deserialize,
+            // mirroring the resilience of query_activities.
+            match serde_json::from_str(json_text.as_str()) {
+                Ok(actor) => out.push(actor),
+                Err(err) => warn!("skipping un-parseable actor row: {err}"),
+            }
         }
         Ok(out)
     }

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -24,8 +24,12 @@ pub struct DownloadTask {
 impl DownloadTask {
     async fn execute(self) -> Result<DownloadTask> {
         // todo: download with progress narration? https://gist.github.com/giuliano-oliveira/4d11d6b3bb003dba3a1b53f43d81b30d
-        let client = reqwest::ClientBuilder::new().build().unwrap();
-        let response = client.get(self.url.clone()).send().await?;
+        let client = reqwest::ClientBuilder::new().build()?;
+        let response = client
+            .get(self.url.clone())
+            .send()
+            .await?
+            .error_for_status()?;
 
         let file_parent_path = self.destination.parent().ok_or(anyhow!("no parent path"))?;
         fs::create_dir_all(file_parent_path)?;

--- a/src/mastodon/importer.rs
+++ b/src/mastodon/importer.rs
@@ -57,7 +57,7 @@ impl Importer {
             "gz" => self.import_tar(file, true)?,
             "tar" => self.import_tar(file, false)?,
             "zip" => self.import_zip(file)?,
-            _ => println!("NO SCANNER AVAILABLE"),
+            other => return Err(anyhow!("unsupported archive format: {other}")),
         };
 
         Ok(())
@@ -81,10 +81,10 @@ impl Importer {
     }
 
     pub fn import_zip(&mut self, file: File) -> Result<()> {
-        let mut archive = zip::ZipArchive::new(file).unwrap();
+        let mut archive = zip::ZipArchive::new(file)?;
 
         for i in 0..archive.len() {
-            let mut file = archive.by_index(i).unwrap();
+            let mut file = archive.by_index(i)?;
             let outpath = match file.enclosed_name() {
                 Some(path) => path.to_owned(),
                 None => continue,

--- a/src/mastodon/instance.rs
+++ b/src/mastodon/instance.rs
@@ -1,6 +1,6 @@
 use crate::config;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -88,10 +88,10 @@ pub async fn register_client_app(
     params.insert("scopes", OAUTH_SCOPES);
 
     let url = format!("https://{instance}/api/v1/apps");
-    let client = reqwest::ClientBuilder::new().build().unwrap();
-    let res = client.post(url).json(&params).send().await?;
+    let client = reqwest::Client::new();
 
     debug!("Registering new app with instance {}", instance);
+    let res = client.post(url).json(&params).send().await?;
 
     if res.status() == reqwest::StatusCode::OK {
         let result: AppRegistrationResult = res.json().await?;
@@ -100,8 +100,8 @@ pub async fn register_client_app(
         instance_config.vapid_key = Some(result.vapid_key);
         Ok(())
     } else {
-        // todo: throw an error here
-        error!("Failed to register app");
-        Ok(())
+        let status = res.status();
+        let body = res.text().await.unwrap_or_default();
+        Err(anyhow!("failed to register app: {status} - {body}"))
     }
 }

--- a/src/resources/themes/default/web/lib/media-lightbox.js
+++ b/src/resources/themes/default/web/lib/media-lightbox.js
@@ -142,7 +142,9 @@ class MediaLightbox extends HTMLElement {
     img.setAttribute("title", description);
 
     const descriptionEl = this.querySelector(".description");
-    descriptionEl.innerHTML = description;
+    // Media descriptions are user/remote-authored alt-text; assign as text to
+    // avoid HTML injection into the generated archive pages.
+    descriptionEl.textContent = description;
     descriptionEl.classList[!!description ? "add" : "remove"]("visible");
 
     this.previous = previous;

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -48,12 +48,10 @@ pub fn filter_sha256(value: &Value, _: &HashMap<String, Value>) -> tera::Result<
 
 /// Strip a URL down to just its path
 pub fn filter_urlpath(value: &Value, _: &HashMap<String, Value>) -> tera::Result<Value> {
-    let s = try_get_value!("filter_sha256", "value", String, value);
-    // todo: this is pretty ugly:
+    let s = try_get_value!("filter_urlpath", "value", String, value);
     let url = Url::parse("http://example.com")
-        .unwrap()
-        .join(s.as_str())
-        .unwrap();
+        .and_then(|base| base.join(s.as_str()))
+        .map_err(tera::Error::msg)?;
     Ok(to_value(url.path()).unwrap())
 }
 


### PR DESCRIPTION
## Summary

Code-review pass on the project after a period away. Low-risk, high-value fixes are committed here; larger concerns were filed as issues (#49–#58) rather than bundled into this PR.

Verified: `cargo fmt --all -- --check` ✅ · `cargo clippy --all-targets --locked -- -D warnings` ✅ · `cargo test` (11 passing) ✅

## What's in this PR

**Error handling & safety (`850cee9`)** — replace panics with error propagation and stop swallowing failures across 12 files:
- `downloader`: check HTTP status via `error_for_status()` before writing the body (a 404/500 error page was previously saved as media); propagate the client-build error
- `config::init`, `db::conn`, `cli/build`: use `?` instead of `unwrap()`
- `cli/serve`: clean error on bad host/port; `Path::display()` instead of `unwrap()`
- `cli/mastodon/code`, `mastodon/instance`: return `Err` on failure paths that previously logged-and-returned `Ok(())`; drop the access-token debug `println!` (secret leak)
- `mastodon/importer`: propagate zip errors; error on unsupported archive formats instead of silently succeeding
- `db/actors::get_actors`: skip un-parseable rows with a warning instead of aborting (matches `query_activities`)
- `templates::filter_urlpath`: fix copy-pasted error label; return a tera error instead of panicking
- DB count query returns `i64` and drops a meaningless `ORDER BY`
- `activitystreams`: `unwrap_or_else` instead of `or_else(|| Some(..)).unwrap()`

**Frontend (`321d105`)** — render media alt-text via `textContent` instead of `innerHTML` (HTML-injection surface in generated pages).

**Tooling & hygiene (`6b8c106`)**:
- `Makefile` with `check`/`fmt`/`lint`/`test`/`build`/`serve`/`docs`
- CI: fast `fmt` + `clippy -D warnings` lint gate
- `.gitignore`: guard root-level build/backup archives from accidental commits (anchored so `src/resources/test/` fixtures stay addable)

**Docs (`4b2313a`, `a9ca488`)** — code-review session notes under `docs/dev-sessions/`.

## Follow-up issues filed

Security: #49 (zip-slip in tar import), #50 (`| safe` on remote HTML).
Reliability/correctness: #51 (downloader swallows failures/no timeouts), #52 (panicking `From` → `TryFrom`), #53 (DB transaction leak), #57 (federated actor URLs).
Maintainability: #54 (dependency consolidation), #55 (config testability), #56 (migration validation test), #58 (cleanup grab-bag).

The known "exits 0 on failure" bug is already handled in the separate `fix-cli-exit-code` branch, so it's intentionally not duplicated here — but note #51 means `fetch` can still under-report failures even after that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
