### PR TITLE
Rust modernization PR 1/2: util extraction, anyhow unification, curated clippy::pedantic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,10 +590,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
+name = "dotenvy"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "either"
@@ -724,7 +724,7 @@ dependencies = [
  "chrono",
  "clap",
  "config",
- "dotenv",
+ "dotenvy",
  "env_logger",
  "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1.0.71"
 chrono = { version = "0.4.26", features = ["serde"] }
 clap = { version = "4.3.8", features = ["derive", "env", "cargo"] }
 config = "0.13.3"
-dotenv = "0.15.0"
+dotenvy = "0.15"
 env_logger = "0.10.0"
 fallible-iterator = "0.3.0"
 flate2 = "1.0.26"

--- a/docs/dev-sessions/2026-07-23-1637-rust-modernization/notes.md
+++ b/docs/dev-sessions/2026-07-23-1637-rust-modernization/notes.md
@@ -1,0 +1,28 @@
+# Notes — Rust modernization sweep
+
+## PR 1 (phases 1–4) — idiom polish, complete
+
+Baseline preserved throughout: build ✅, 12 unit + `exit_code` integration test ✅, clippy `-D warnings` ✅, fmt ✅. No behavior change.
+
+### Curated `clippy::pedantic` allow-list (Phase 4)
+Enabled `#![warn(clippy::pedantic)]` in `lib.rs` + `main.rs`. Did **not** add `nursery` (kept scope to pedantic; nursery can be a later pass). Deliberate `#![allow(...)]` (documented in the attribute block), each because it's noise for a CLI app rather than a library:
+- `must_use_candidate`, `missing_errors_doc`, `missing_panics_doc`, `module_name_repetitions` — doc/API-surface noise
+- `unused_async` — CLI `command` fns share a uniform `async fn(...) -> Result<()>` dispatch shape; some don't await
+- `implicit_hasher` — generalizing app fns over `BuildHasher` is library-only noise
+- `struct_excessive_bools` — clap `Args` structs are legitimately several bool flags
+- `non_std_lazy_statics` — the `lazy_static!` → `std::sync::LazyLock` swap is a **dep-graph change**, deferred to PR 2 (PR 1 is dep-graph-neutral)
+
+Plus one **module-scoped** allow: `#![allow(clippy::manual_string_new)]` in `config.rs` — `DEFAULT_CONFIG = include_str!("./resources/default_config.toml").to_string()` binds to a template file that is currently 0 bytes, so clippy wants `String::new()`; keeping the `include_str!` binding preserves the link for when the template gains content.
+
+### Everything else in Phase 4 was fixed, not allowed
+Auto-fixed (clippy --fix): uninlined format args, needless raw-string hashes, redundant semicolons, `if !x {..} else {..}` inversions, ignored-unit patterns, redundant closure. Manual: merged identical match arms (`Video | Gifv`), `match_wildcard_for_single_variants` (`_ =>` → `ActivitySchema::Unknown(name) =>`), `unnecessary_wraps` on a test fn, `needless_pass_by_value` (`Importer::import(PathBuf)` → `&Path`), `assigning_clones` (`clone_from`). Plus contained idioms: `&bool` → `bool` (setup_build/data_path + callers), `total_items: i32` → `u64`.
+
+### ⚠️ Destructive-autofix caught
+`clippy --fix` rewrote `DEFAULT_CONFIG`'s `include_str!(..).to_string()` to `String::new()` (manual_string_new, because the template is empty). Reverted — it severs the file binding. Resolved with the scoped allow above instead.
+
+### Deferred (deliberately NOT done in PR 1)
+- **Broad `&String`/`&PathBuf`/`&Vec<T>` → `&str`/`&Path`/`&[T]` sweep.** These are *not* flagged even under pedantic — they're shielded (each `&PathBuf`/`&String` is forwarded to another fn that itself wants the owned-ref type, e.g. rusqlite params, `fs_extra`, generic `&P`). Forcing them risks an unshielding cascade with no clippy backing. Left as a focused follow-up if wanted. (Phase 1 did convert the two `themes` fns the util extraction *unshielded*.)
+- `lazy_static!` → `LazyLock` (see `non_std_lazy_statics` above) → PR 2 or a follow-up.
+
+## PR 2 (phases 5–6) — deps/TLS — NOT STARTED
+Pending: reqwest 0.11→0.12 + rustls-tls, drop `openssl`, narrow tokio features, Docker/CI cleanup. Full CI cross-build matrix required.

--- a/docs/dev-sessions/2026-07-23-1637-rust-modernization/plan.md
+++ b/docs/dev-sessions/2026-07-23-1637-rust-modernization/plan.md
@@ -1,0 +1,256 @@
+# Rust Modernization Sweep — Implementation Plan
+
+**Goal:** Modernize idiom and collapse the duplicated dependency stack with zero behavior change, delivered as two independent PRs.
+
+**Approach:** PR 1 (phases 1–4) is non-behavioral polish verifiable on the standard build: extract shared utils, unify on `anyhow`, swap dotenvy, then enable curated `clippy::pedantic` and fix idioms. PR 2 (phases 5–6) is the behavioral-but-preserving dep/TLS migration verified by the full CI matrix. One commit per phase (`Phase N: <name>`).
+
+**Tech stack:** Rust 2021, anyhow, rust_embed, reqwest, rustls, tokio, clippy.
+
+**TDD note:** This is a refactoring sweep with no intended behavior change, so per SKILL.md the existing suite (12 tests) is the regression net — phases are **opt-out of test-first** except Phase 1, which adds direct unit tests for the newly extracted `util` module. Every phase must keep `make test` green.
+
+---
+
+## PR 1 — Idiom polish
+
+### Phase 1: Extract shared `util` module
+
+Dedupe `open_outfile_with_parent_dir` and consolidate embedded-asset copying into one generic helper; delete the dead generic.
+
+**Files:**
+- Create: `src/util.rs`
+- Modify: `src/lib.rs` — add `pub mod util;`
+- Modify: `src/themes.rs` — delete local `open_outfile_with_parent_dir` (75-80); reimplement `copy_embedded_themes` (11) and `copy_embedded_web_assets` (24) as thin wrappers over the generic; keep `templates_source` and `ThemeAsset` as-is
+- Modify: `src/site_generator.rs` — delete local `open_outfile_with_parent_dir` (74-79) and the **dead** generic `copy_embedded_assets` (59-72, no call sites); import from `util`; update `unpack_customizable_resources`/`copy_web_assets` call sites
+- Test: unit tests in `src/util.rs`
+
+**Key changes** — `src/util.rs` returns the target `anyhow::Result` convention from the start:
+```rust
+use anyhow::{anyhow, Result};
+use rust_embed::RustEmbed;
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+/// Create the parent directory (if needed) and open `outpath` for writing.
+pub fn open_outfile_with_parent_dir(outpath: &Path) -> Result<fs::File> {
+    let outparent = outpath
+        .parent()
+        .ok_or_else(|| anyhow!("no parent path for {}", outpath.display()))?;
+    fs::create_dir_all(outparent)?;
+    Ok(fs::File::create(outpath)?)
+}
+
+/// Copy every embedded asset from a `RustEmbed` folder into `output_path`.
+/// If `strip_prefix` is set, only assets under that prefix are copied and the
+/// prefix is removed from their output path.
+pub fn copy_embedded_assets<Assets: RustEmbed>(
+    output_path: &Path,
+    strip_prefix: Option<&str>,
+) -> Result<()> {
+    for filename in Assets::iter() {
+        let name = filename.as_ref();
+        let rel = match strip_prefix {
+            Some(prefix) => match Path::new(name).strip_prefix(prefix) {
+                Ok(r) => r.to_path_buf(),
+                Err(_) => continue,
+            },
+            None => Path::new(name).to_path_buf(),
+        };
+        let asset = Assets::get(name).ok_or_else(|| anyhow!("missing embedded asset {name}"))?;
+        let outpath = output_path.join(rel);
+        let mut outfile = open_outfile_with_parent_dir(&outpath)?;
+        outfile.write_all(asset.data.as_ref())?;
+        debug!("Wrote {name} to {}", outpath.display());
+    }
+    Ok(())
+}
+```
+- `themes::copy_embedded_themes(out)` → `util::copy_embedded_assets::<ThemeAsset>(out, None)`
+- `themes::copy_embedded_web_assets(theme, out)` → `util::copy_embedded_assets::<ThemeAsset>(out, Some(&format!("{theme}/web")))`  (preserves the current `<theme>/web` strip; the old code strips a `PathBuf(theme).join("web")` prefix — same thing)
+- Wrappers keep existing signatures so callers in `cli/build.rs`/`site_generator.rs` are untouched this phase.
+
+**Tests (`src/util.rs`):**
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn open_outfile_creates_missing_parent_dirs() {
+        let dir = std::env::temp_dir().join(format!("fossilizer-util-{}", std::process::id()));
+        let target = dir.join("a/b/c.txt");
+        let _ = std::fs::remove_dir_all(&dir);
+        let mut f = open_outfile_with_parent_dir(&target).unwrap();
+        use std::io::Write;
+        f.write_all(b"ok").unwrap();
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "ok");
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+}
+```
+(A `copy_embedded_assets` test would need a fixture `RustEmbed` type; the existing `templates.rs`/build integration already exercises `ThemeAsset` copying, so `open_outfile` direct coverage is the targeted addition here.)
+
+**Verification — automated:**
+- [ ] `make test` passes (incl. new `util` test)
+- [ ] `make lint` passes
+- [ ] `cargo build --locked` succeeds
+
+**Verification — manual:**
+- [ ] `grep -rn "open_outfile_with_parent_dir" src/` shows the definition only in `util.rs`
+- [ ] `grep -rn "fn copy_embedded_assets" src/` shows it only in `util.rs`
+
+---
+
+### Phase 2: Unify error handling on `anyhow::Result`
+
+Replace every `Result<_, Box<dyn Error>>` in `src/` with `anyhow::Result<_>`; convert string/boxed error production to anyhow idioms.
+
+**Files (all `Box<dyn Error>` sites from `research.md`):** `src/config.rs`, `src/db.rs`, `src/themes.rs`, `src/site_generator.rs`, `src/app.rs`, `src/templates.rs`, `src/cli.rs`, `src/mastodon/instance.rs`, `src/db/actors.rs`, and every `src/cli/*.rs` + `src/cli/mastodon/*.rs` `command` fn. Also the `Result<_, Box<dyn Error>>` test fns in `src/activitystreams.rs` and the commented-out block in `src/templates.rs`.
+
+**Mechanical recipe (apply per file):**
+1. Signature: `Result<T, Box<dyn Error>>` → `anyhow::Result<T>` (written as `Result<T>` with `use anyhow::Result;`).
+2. Imports: remove `use std::error::Error;` where it becomes unused; ensure `use anyhow::{anyhow, Context, Result};` (add only the parts used).
+3. Error production conversions:
+   - `.ok_or("msg")?` → `.context("msg")?` (for `Option`) — e.g. `db.rs:34`, `site_generator.rs:63/248`, `templates.rs:27/64`
+   - `return Err(Box::new(err));` → `return Err(err.into());` or `return Err(anyhow!(...))` — `site_generator.rs:21,38`
+   - `format!(...).into()` in `Err` → `anyhow!(...)` / `bail!(...)` — `cli/mastodon/code.rs:60`
+   - `.ok_or_else(|| String)` → `.ok_or_else(|| anyhow!(...))` — `cli/mastodon/code.rs:30-31,35,39`
+   - `.map_err(|e| format!(...))?` → `.map_err(|e| anyhow!(...))?` or `.with_context(|| ...)?` — `cli/serve.rs:30`
+4. Leave existing `anyhow!`, `??`-on-JoinHandle, and `db/activities.rs` internal `rusqlite::Error`-typed private helpers (`SingleColumnResult`, `query_single_column`, `get_published_*`) **as-is** — they already convert cleanly via `?` and are not `Box<dyn Error>`.
+
+**Key changes (illustrative):**
+```rust
+// config.rs — before / after
+pub fn init(config_path: &Path) -> Result<(), Box<dyn Error>> { ... }
+pub fn init(config_path: &Path) -> anyhow::Result<()> { ... }   // use anyhow::Result
+
+// db.rs:34
+let database_parent_path = Path::new(&database_path).parent().ok_or("no parent path")?;
+let database_parent_path = Path::new(&database_path)
+    .parent()
+    .context("database path has no parent directory")?;
+```
+
+**Verification — automated:**
+- [ ] `grep -rn "Box<dyn Error>" src/` returns nothing (or only intentional, documented exceptions)
+- [ ] `grep -rn "use std::error::Error" src/` returns nothing
+- [ ] `make test` passes
+- [ ] `make lint` passes
+- [ ] `cargo build --locked` succeeds
+
+**Verification — manual:**
+- [ ] Error messages on a forced failure (e.g. `fossilizer build` with no DB) still read sensibly, now with anyhow context
+
+---
+
+### Phase 3: `dotenv` → `dotenvy`
+
+Swap the unmaintained crate for its maintained fork.
+
+**Files:**
+- Modify: `Cargo.toml` — replace `dotenv = "0.15.0"` with `dotenvy = "0.15"`
+- Modify: `src/config.rs` — remove bare `use dotenv;` (line 2); change `dotenv::dotenv().ok();` (line 67) → `dotenvy::dotenv().ok();`
+
+**Verification — automated:**
+- [ ] `cargo build --locked` succeeds
+- [ ] `make test` passes
+- [ ] `grep -rn "dotenv::" src/` returns nothing (only `dotenvy::`)
+
+**Verification — manual:**
+- [ ] A `.env` with `APP_LOG_LEVEL=debug` (or similar) is still honored by `fossilizer`
+
+---
+
+### Phase 4: Curated `clippy::pedantic` + idiom fixes
+
+Turn on the stricter lint set, curate the allow-list, and fix flagged idioms.
+
+**Files:**
+- Modify: `src/lib.rs` and `src/main.rs` — add the lint attribute block (below)
+- Modify: idiom sites from `research.md` — `&String`→`&str` (`instance.rs`, `db/actors.rs:30`, `db/activities.rs:147/160/205`), `&PathBuf`→`&Path` (throughout), `&Vec<T>`→`&[T]` (`site_generator.rs`, `contexts.rs:92`), `&bool`→`bool` (`site_generator.rs:15/29`, deref `if *clean`→`if clean`), `total_items: i32`→`u64` (`activitystreams.rs:97/113/119`), manual push-loops → iterator chains where clippy flags (`activitystreams.rs:352-364`)
+- No change needed to `.github/workflows/ci.yml` / `Makefile` (already `clippy --all-targets -- -D warnings`; the crate-level attrs drive pedantic)
+
+**Key changes** — lint block (starting point; refine allow-list against real output, record final set in `notes.md`):
+```rust
+#![warn(clippy::pedantic, clippy::nursery)]
+#![allow(
+    clippy::must_use_candidate,
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::module_name_repetitions,
+    clippy::missing_const_for_fn
+)]
+```
+- Callers of signature-changed fns update accordingly (e.g. `&String`→`&str` and `&PathBuf`→`&Path` callers usually need no change — the references coerce).
+- If a pedantic lint demands a change that risks behavior or is pure noise, add it to the `allow` block instead and note why.
+
+**Verification — automated:**
+- [ ] `cargo clippy --all-targets --locked -- -D warnings` passes with pedantic+nursery enabled
+- [ ] `cargo fmt --all -- --check` passes
+- [ ] `make test` passes
+
+**Verification — manual:**
+- [ ] Final `#![allow(...)]` set and rationale recorded in `notes.md`
+
+**→ PR 1 boundary:** run `/dev-session pr` here (self-review, push, open PR, Copilot review). PR 1 is complete and mergeable before PR 2 begins.
+
+---
+
+## PR 2 — Dependency / TLS consolidation
+
+*(Branch PR 2 from `main` after PR 1 merges, or stack on PR 1 if it hasn't merged yet — note the base in the PR.)*
+
+### Phase 5: Migrate `reqwest` 0.11 → 0.12 with rustls
+
+Bump the direct dependency and migrate call sites; converge on rustls.
+
+**Files:**
+- Modify: `Cargo.toml:38` — `reqwest = { version = "0.12", default-features = false, features = ["gzip", "json", "rustls-tls"] }`
+- Modify (per `research.md` §reqwest): `src/downloader.rs`, `src/mastodon/instance.rs`, `src/cli/fetch.rs`, `src/cli/mastodon/code.rs`, `src/cli/mastodon/link.rs`, `src/cli/mastodon/verify.rs`
+- Modify: `Cargo.lock` (via `cargo build`)
+
+**Key changes:**
+- The used API surface (`Client`, `ClientBuilder`, `get`/`post`, `json`, `send`, `bytes`, `text`, `error_for_status`, `StatusCode`, `header::*`, `Url::parse_with_params`) is unchanged across 0.11→0.12 — expect a near-drop-in bump. Fix `cli/mastodon/verify.rs:34` `.build().unwrap()` → `.build()?` while touching it.
+- Verify no code depended on native-tls-specific behavior (none found in `research.md`).
+
+**Verification — automated:**
+- [ ] `cargo build --locked` succeeds
+- [ ] `make test` passes
+- [ ] `cargo tree -i reqwest` shows a **single** version (0.12.x)
+- [ ] `cargo tree -i native-tls` returns nothing
+
+**Verification — manual:**
+- [ ] `fossilizer mastodon` auth flow and a real `fetch`/media download still work against a live instance (or note as CI-only if no instance handy)
+
+---
+
+### Phase 6: Drop OpenSSL, narrow tokio features, clean Docker/CI
+
+Remove the now-unused vendored OpenSSL and trim tokio; let the full CI matrix prove the musl/darwin/windows builds.
+
+**Files:**
+- Modify: `Cargo.toml:39` — remove the `openssl = { version = "0.10.55", features = ["vendored"] }` line
+- Modify: `Cargo.toml:36` — `tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }` (drop `"full"` and bogus `"windows-sys"`; add back any feature the compiler/CI demands and record it)
+- Modify: `Dockerfile` — remove `libssl-dev` from the apt install (~line 7) if the build no longer needs it (keep only if bundled-sqlite still requires it — verify)
+- Modify: `.github/workflows/ci.yml` — no OpenSSL apt step exists to remove; confirm musl-tools step still sufficient
+
+**Verification — automated:**
+- [ ] `cargo build --locked` succeeds locally
+- [ ] `make test` passes
+- [ ] `cargo tree -i openssl` returns nothing
+- [ ] `cargo tree -i openssl-sys` returns nothing
+
+**Verification — manual (CI-gated):**
+- [ ] Full CI matrix green on the PR: musl x86_64 / aarch64 / arm, darwin x86_64 / aarch64, windows-msvc
+- [ ] Docker image still builds (`docker build .`) without libssl-dev
+- [ ] Final tokio feature set recorded in `notes.md`
+
+**→ PR 2 boundary:** run `/dev-session pr`; requires the full matrix (not just PR quick-test) to be green before merge.
+
+---
+
+## Plan self-review
+
+- **Spec coverage:** util extraction → P1; anyhow unification → P2; dotenvy → P3; curated pedantic + idioms → P4; reqwest 0.12/rustls → P5; drop openssl + tokio narrowing + Docker → P6. All spec requirements mapped.
+- **Placeholder scan:** no TBD/TODO; the two "record final set in notes.md" items are deliberate outputs of curation, each with a concrete starting set given.
+- **Type consistency:** `util::open_outfile_with_parent_dir(&Path) -> Result<fs::File>` and `util::copy_embedded_assets::<A: RustEmbed>(&Path, Option<&str>) -> Result<()>` are referenced consistently in P1 and unaffected by later phases; `anyhow::Result` naming consistent P2 onward.
+- **Scope discipline:** filed issues #49–#53/#57/#61/#60/#55 explicitly excluded per spec; no drive-by fixes.

--- a/docs/dev-sessions/2026-07-23-1637-rust-modernization/plan.md
+++ b/docs/dev-sessions/2026-07-23-1637-rust-modernization/plan.md
@@ -159,12 +159,12 @@ Swap the unmaintained crate for its maintained fork.
 - Modify: `src/config.rs` — remove bare `use dotenv;` (line 2); change `dotenv::dotenv().ok();` (line 67) → `dotenvy::dotenv().ok();`
 
 **Verification — automated:**
-- [ ] `cargo build --locked` succeeds
-- [ ] `make test` passes
-- [ ] `grep -rn "dotenv::" src/` returns nothing (only `dotenvy::`)
+- [x] `cargo build --locked` succeeds (lock refreshed: `dotenvy` in, `dotenv` out)
+- [x] `make test` passes
+- [x] `grep -rn "dotenv::" src/` returns nothing (only `dotenvy::`)
 
 **Verification — manual:**
-- [ ] A `.env` with `APP_LOG_LEVEL=debug` (or similar) is still honored by `fossilizer`
+- [x] `dotenvy` is an API-compatible fork; `dotenvy::dotenv().ok()` behaves identically to the old call (verified by inspection — same signature, same env-loading semantics)
 
 ---
 

--- a/docs/dev-sessions/2026-07-23-1637-rust-modernization/plan.md
+++ b/docs/dev-sessions/2026-07-23-1637-rust-modernization/plan.md
@@ -192,12 +192,17 @@ Turn on the stricter lint set, curate the allow-list, and fix flagged idioms.
 - If a pedantic lint demands a change that risks behavior or is pure noise, add it to the `allow` block instead and note why.
 
 **Verification — automated:**
-- [ ] `cargo clippy --all-targets --locked -- -D warnings` passes with pedantic+nursery enabled
-- [ ] `cargo fmt --all -- --check` passes
-- [ ] `make test` passes
+- [x] `cargo clippy --all-targets --locked -- -D warnings` passes with pedantic enabled (nursery deferred — see notes)
+- [x] `cargo fmt --all -- --check` passes
+- [x] `make test` passes (12 + exit_code)
 
 **Verification — manual:**
-- [ ] Final `#![allow(...)]` set and rationale recorded in `notes.md`
+- [x] Final `#![allow(...)]` set and rationale recorded in `notes.md`
+
+**Adaptation notes:**
+- Scope kept to `clippy::pedantic` (not `nursery`) — nursery is unstable/noisy; can be a later pass.
+- Caught and reverted a **destructive** `clippy --fix`: it collapsed `DEFAULT_CONFIG`'s `include_str!(..).to_string()` to `String::new()` (empty template file). Resolved with a module-scoped `#![allow(clippy::manual_string_new)]` in `config.rs`.
+- The broad `&String`/`&PathBuf`/`&Vec<T>` idiom sweep is **not** flagged by pedantic (shielded by forwarding) — deliberately deferred rather than forced (would risk an unshielding cascade with no clippy backing). Only the contained, unambiguous ones done: `&bool`→`bool`, `total_items: i32`→`u64`, plus the pass-by-value `Importer::import`.
 
 **→ PR 1 boundary:** run `/dev-session pr` here (self-review, push, open PR, Copilot review). PR 1 is complete and mergeable before PR 2 begins.
 

--- a/docs/dev-sessions/2026-07-23-1637-rust-modernization/plan.md
+++ b/docs/dev-sessions/2026-07-23-1637-rust-modernization/plan.md
@@ -90,13 +90,15 @@ mod tests {
 (A `copy_embedded_assets` test would need a fixture `RustEmbed` type; the existing `templates.rs`/build integration already exercises `ThemeAsset` copying, so `open_outfile` direct coverage is the targeted addition here.)
 
 **Verification — automated:**
-- [ ] `make test` passes (incl. new `util` test)
-- [ ] `make lint` passes
-- [ ] `cargo build --locked` succeeds
+- [x] `make test` passes (incl. new `util` test) — 12 unit + exit_code integration
+- [x] `make lint` passes (clippy `-D warnings`)
+- [x] `cargo build --locked` succeeds
 
 **Verification — manual:**
-- [ ] `grep -rn "open_outfile_with_parent_dir" src/` shows the definition only in `util.rs`
-- [ ] `grep -rn "fn copy_embedded_assets" src/` shows it only in `util.rs`
+- [x] `grep -rn "open_outfile_with_parent_dir" src/` shows the definition only in `util.rs`
+- [x] `grep -rn "fn copy_embedded_assets" src/` shows it only in `util.rs`
+
+**Adaptation note:** Extracting `util` unshielded clippy `ptr_arg` on `themes::copy_embedded_themes`/`copy_embedded_web_assets` (they used to forward `&PathBuf` to a `&PathBuf`-taking local fn; now they forward to `util`'s `&Path` fn). Pulled those two `&PathBuf`→`&Path` fixes forward from Phase 4 to keep this commit lint-green. No cascade beyond the two (their caller `copy_web_assets` still forwards to a generic `&P` fn, so it stays shielded until Phase 4).
 
 ---
 

--- a/docs/dev-sessions/2026-07-23-1637-rust-modernization/plan.md
+++ b/docs/dev-sessions/2026-07-23-1637-rust-modernization/plan.md
@@ -133,14 +133,20 @@ let database_parent_path = Path::new(&database_path)
 ```
 
 **Verification — automated:**
-- [ ] `grep -rn "Box<dyn Error>" src/` returns nothing (or only intentional, documented exceptions)
-- [ ] `grep -rn "use std::error::Error" src/` returns nothing
-- [ ] `make test` passes
-- [ ] `make lint` passes
-- [ ] `cargo build --locked` succeeds
+- [x] `grep -rn "Box<dyn Error>" src/` returns nothing (except the dead, non-compiled `src/cli/fetch.rs` — see note)
+- [x] `grep -rn "use std::error::Error" src/` returns nothing (except dead `src/cli/fetch.rs`)
+- [x] `make test` passes (12 unit + exit_code)
+- [x] `make lint` passes (clippy `-D warnings`)
+- [x] `cargo build --locked` succeeds
 
 **Verification — manual:**
-- [ ] Error messages on a forced failure (e.g. `fossilizer build` with no DB) still read sensibly, now with anyhow context
+- [x] Forced failure `cargo run -- build` (no DB) prints a clean anyhow chain: `Error: no such table: actors` / `Caused by: ...`
+
+**Adaptation notes:**
+- `config.rs` `RwLock` `PoisonError` is `!Send`, so it can't propagate via `?` under anyhow (which needs `Send + Sync + 'static`). Converted the 5 lock sites to `.map_err(|e| anyhow!("config context lock poisoned: {e}"))?`.
+- `.ok_or("str")?` doesn't compile under anyhow (no `From<&str>`); converted to `.context("str")?` (added `anyhow::Context` imports, incl. into the activitystreams test module).
+- `serve.rs`/`code.rs` string-based errors from the earlier review PR (`format!(..).into()`, `String` closure) converted to `anyhow!`.
+- **`src/cli/fetch.rs` intentionally left on `Box<dyn Error>`**: it is not a declared module (dead/uncompiled), tracked for deletion/wiring by #58/#12. Excluded from the grep checks.
 
 ---
 

--- a/docs/dev-sessions/2026-07-23-1637-rust-modernization/research.md
+++ b/docs/dev-sessions/2026-07-23-1637-rust-modernization/research.md
@@ -1,0 +1,77 @@
+# Research — Rust modernization sweep
+
+Baseline: build ✅, 12 tests ✅ (11 unit + `tests/exit_code.rs`), clippy `-D warnings` ✅ (default lints). From two documentarian passes on the worktree.
+
+## Error-type surface (anyhow unification scope)
+
+Many files import **both** `use anyhow::Result;` and `use std::error::Error;`. Written form decides resolution: `Result<T, Box<dyn Error>>` = std; `Result<T>` = anyhow.
+
+**Return `Result<_, Box<dyn Error>>` (→ migrate to `anyhow::Result`):**
+- `config.rs`: init:66, config:84, update:88, get:97, try_deserialize:104
+- `db.rs`: conn:30, upgrade:47
+- `themes.rs`: copy_embedded_themes:11, copy_embedded_web_assets:24, open_outfile_with_parent_dir:75
+- `site_generator.rs`: setup_build_path:15, setup_data_path:29, unpack_customizable_resources:47, copy_embedded_assets:59, open_outfile_with_parent_dir:74, copy_web_assets:81, copy_files:99, plan_activities_pages:126, generate_activities_pages:153, generate_activity_page:166, generate_index_page:212, generate_index_json:236
+- `app.rs`: init:8, init_logging:14
+- `templates.rs`: init:16, render_to_file:58
+- `cli.rs`: execute:54
+- `mastodon/instance.rs`: build_instance_config_path:35, load_instance_config:42, save_instance_config:57
+- `db/actors.rs`: get_actor:28, get_actors_by_id:57
+- all `cli/*` `command` fns (build:28, import:19, init:18, serve:21, upgrade:9, fetch:19, mastodon:33, mastodon/code:22, link:12, verify:20, fetch:22)
+- test fns in activitystreams.rs (438,455,482,502,530), templates.rs (88, commented-out)
+
+**Already `anyhow::Result` (the target convention):** downloader (execute:25, queue:70, close:77, run:82), fetcher.fetch:48, instance.register_client_app:80, importer (import:46, import_tar:66, import_zip:83, handle_*:101/127/150/158), db/actors (import_actor:18, get_actors:39), db/activities (import*, get_activities*, count:231, query_count:265, query_activities:279, upgrade_status_json:338). `ActivitySchema::FromStr` uses `type Err = anyhow::Error` (activities.rs:25).
+
+**Typed `rusqlite::Error` (internal helpers, keep or convert):** `SingleColumnResult` (activities.rs:246), get_published_* (134/147/160/173/187), query_single_column:252.
+
+**Error-production idioms to convert during migration:**
+- `.ok_or("string")?` (String→Box): db.rs:34, themes.rs:13/42/76, site_generator.rs:63/75/248, templates.rs:27/64 → `.ok_or_else(|| anyhow!(...))` or `.context(...)`
+- `Box::new(err)`: site_generator.rs:21, 38 → `?`/`.into()`/anyhow
+- `format!(...).into()`: cli/mastodon/code.rs:60 → `anyhow!` / `bail!`
+- Already-anyhow: `anyhow!` at instance.rs:105, importer.rs:53/55/60, activities.rs:274/329, downloader.rs:34/94/103
+- `.context(...)` currently used **nowhere** (opportunity)
+- `??` on JoinHandles (fetcher.rs:143, cli/fetch.rs:118-119) relies on anyhow — stays fine
+
+**Cross-style boundaries (anyhow→Box via `?` today; disappear after unification):** actors.rs:60-61, cli/mastodon/link.rs:20, cli/mastodon/fetch.rs:44, cli/import.rs:35, cli/fetch.rs (many).
+
+## Duplicated / shared utilities (extract to `util` module)
+
+- `open_outfile_with_parent_dir` — **byte-identical duplicate**: themes.rs:75 (used 16,45) and site_generator.rs:74 (used 50,66). Body: `parent().ok_or(..)? → create_dir_all? → File::create`.
+- Embedded-asset copy: `copy_embedded_themes` (themes.rs:11) and generic `copy_embedded_assets<RustEmbed>` (site_generator.rs:59) are near-identical; **`copy_embedded_assets` has NO call sites (dead)** and carries `// todo: move this to a shared utils module` (site_generator.rs:58). `copy_embedded_web_assets` (themes.rs:24) filters by `<theme>/web`. rust_embed type is `ThemeAsset` (themes.rs:7-9). `templates_source` (themes.rs:53) also iterates ThemeAsset.
+- Plan: one generic embedded writer in `util`; themes fns delegate; delete the dead generic.
+
+## dotenv → dotenvy
+- `config.rs:2` `use dotenv;` (bare import), `config.rs:67` `dotenv::dotenv().ok();`, `Cargo.toml:14` `dotenv = "0.15.0"`. Only references.
+
+## Idiom / clippy-pedantic candidates (ptr_arg / trivially_copy)
+- `&String`: instance.rs 35/42/58/81, actors.rs:30, activities.rs 147/160/205
+- `&PathBuf` (→`&Path`): themes 11/26/75, site_generator 15/60/74/81/127/154/167/213/237, importer 101/127, activitystreams:31, templates:60
+- `&Vec<T>` (→`&[T]`): site_generator 157/214/238, contexts.rs:92 (`From<&Vec<IndexDayContext>>`)
+- `&bool` (→`bool`): site_generator setup_build_path:15, setup_data_path:29 (deref `if *clean`)
+- Other agent-noted nits: `total_items: i32` for counts (activitystreams 97/113/119), manual push-loops in `Attachments for Object` (activitystreams 352-364)
+- NOTE: default clippy passes clean today — pedantic pass will reveal the true set; curate allows.
+
+## reqwest / TLS / deps (PR 2)
+
+**Direct reqwest 0.11 usage (all in `src/`, migrate to 0.12 API):**
+- downloader.rs:27 ClientBuilder::new().build()?, :28-32 get().send().error_for_status()?, :38 .bytes()
+- instance.rs:91 Client::new(), :94 post().json().send(), :96 StatusCode::OK, :97 .json(), :104 .text()
+- cli/fetch.rs:2 `use reqwest::header`, :34-41 HeaderMap + ClientBuilder.default_headers, :45/73/78-83 get().send().json()
+- cli/mastodon/code.rs:50 Client::new(), :51 post().json().send(), :53 StatusCode::OK
+- cli/mastodon/link.rs:31 reqwest::Url::parse_with_params
+- cli/mastodon/verify.rs:34 ClientBuilder::new().build().unwrap() (still has an unwrap!), :35-39 get().header().send(), :41 StatusCode::OK
+- No `reqwest::Error` by name, no `.query()`. API surface is 0.12-compatible.
+
+**Dependency graph today (two of everything):**
+- reqwest **0.11.23** (fossilizer direct, default-tls→native-tls→openssl) AND **0.12.3** (via megalodon + oauth2, `rustls-tls` + webpki-roots)
+- hyper 0.14 (reqwest 0.11, warp, mockito) AND 1.2 (reqwest 0.12)
+- rustls 0.22 & 0.23; native-tls 0.2 (only 0.11 side)
+- tokio-tungstenite 0.21 (**warp**) AND 0.27 (megalodon)
+- **`openssl = {vendored}` (Cargo.toml:39) is NOT referenced in `src/`** — present only to force vendored OpenSSL for musl (Dockerfile:7 comment). Droppable with the 0.11→0.12+rustls switch.
+
+**De-risks the rustls call:** megalodon already builds reqwest 0.12 + rustls (ring) on **every active CI musl target today** → the historical "ring won't cross-compile for musl" blocker is already resolved for shipped targets. Only `i686-unknown-linux-musl` is commented out in CI (`ci.yml:116` "fails on building 'ring'") — already disabled, stays out of scope.
+
+**Residual duplication after PR 2:** `warp 0.3.7` still pulls hyper 0.14 + tokio-tungstenite 0.21. Out of scope (warp upgrade is separate).
+
+**CI (`.github/workflows/ci.yml`):** lint job (fmt+clippy -D warnings), test-pr (musl x86_64), full matrix (musl x86_64/aarch64/arm, darwin x86_64/aarch64, windows-msvc). musl-tools installed; no explicit libssl apt step (vendored). All via `houseabsolute/actions-rust-cross@v0`, `--locked --release`.
+
+**tokio:** `Cargo.toml:36` `features = ["full", "windows-sys"]`. `"windows-sys"` is **not a real tokio feature name**. Actual APIs used: `#[tokio::main]` (main.rs:6), spawn (downloader 88/179, cli/fetch:29), JoinSet (downloader), select! (downloader:119), Notify (downloader), time (downloader tests), join! (test). No `tokio::fs`, no channels. → narrow to a minimal feature set; drop bogus `"windows-sys"`. Verify Windows build.

--- a/docs/dev-sessions/2026-07-23-1637-rust-modernization/spec.md
+++ b/docs/dev-sessions/2026-07-23-1637-rust-modernization/spec.md
@@ -1,0 +1,72 @@
+# Rust Modernization Sweep Spec
+
+**Goal:** Bring fossilizer's Rust up to current idiom and collapse its duplicated dependency stack — without changing behavior — so the codebase reads consistently and builds leaner.
+
+**Source:** User request 2026-07-23 (Les; fossilizer is a Rust learning project, fussy/pedantic fixes explicitly welcome). Relates to issues #54 (dep consolidation), #58 (cleanup grab-bag), #60 (test coverage).
+
+## Current state
+
+Codebase is idiomatically inconsistent in ways typical of a multi-year learning project (see `research.md`):
+- **Error types split** ~evenly between `Result<_, Box<dyn Error>>` (config, db, themes, site_generator, app, templates, cli.rs, instance, actors, all cli commands) and `anyhow::Result` (downloader, fetcher, importer, db/activities, parts of actors). Most files import *both*. `.context()` is used nowhere.
+- **Duplicated utils:** `open_outfile_with_parent_dir` byte-identical in `themes.rs:75` and `site_generator.rs:74`; a dead generic `copy_embedded_assets` (`site_generator.rs:59`, no call sites) with a `// todo: move to shared utils` marker.
+- **Dated idioms:** `&String`/`&PathBuf`/`&Vec<T>`/`&bool` params, `total_items: i32`, bare `use dotenv;` (unmaintained crate).
+- **Duplicated dep stack:** direct `reqwest 0.11` (native-tls→vendored OpenSSL) coexists with `reqwest 0.12` (rustls, via megalodon) → two each of hyper/http/rustls/tungstenite. `openssl = {vendored}` is declared but unreferenced in `src/`. `tokio = ["full", "windows-sys"]` (`"windows-sys"` is not a real tokio feature).
+
+Baseline is green: build ✅, 12 tests ✅, clippy `-D warnings` ✅.
+
+## Desired end state
+
+Delivered as **two independent PRs** off `main`:
+
+**PR 1 — Idiom polish (no behavior change, no dep-graph change):**
+- Curated `clippy::pedantic` (+ selected `nursery`) enabled crate-wide via `#![warn(...)]` in `lib.rs`/`main.rs`, with deliberate `#![allow(...)]` for low-value/noisy lints, and clean under `-D warnings`.
+- All public/internal error types unified on **`anyhow::Result`**; `Box<dyn Error>` removed from `src/`; string-error `.ok_or("..")?` sites converted to `anyhow!`/`.context()`; redundant `use std::error::Error;` imports removed.
+- Single `util` module holding `open_outfile_with_parent_dir` and one generic embedded-asset writer; `themes`/`site_generator` delegate to it; dead `copy_embedded_assets` removed.
+- `dotenv` → `dotenvy`.
+- Reference-param idioms fixed where clippy flags them (`&str`/`&Path`/`&[T]`/`bool`), plus `total_items` to an unsigned type.
+- Tests still green; new unit tests added only where a change alters an error path or the extracted util warrants direct coverage.
+
+**PR 2 — Dependency / TLS consolidation (build change, behavior-preserving):**
+- Direct dep bumped to `reqwest = "0.12"` with `rustls-tls` (drop `default-tls`); the ~6 files using reqwest migrated to the 0.12 API.
+- `openssl` dependency removed; Dockerfile/CI libssl references cleaned up if newly unnecessary.
+- `tokio` features narrowed from `"full"` to the minimal used set; bogus `"windows-sys"` removed.
+- Collapses duplicate reqwest/hyper/http/native-tls/openssl trees. Full CI cross-build matrix (all musl + darwin + windows targets) green.
+
+## Design decisions
+
+- **Decision:** Two PRs — polish first, deps/TLS second.
+  - **Why:** PR 1 is a large mechanical, non-behavioral diff verifiable on the standard build; PR 2 is behavioral (networking/TLS) and only fully verifiable via the CI cross-build matrix. Mixing them makes review and failure-bisection painful. PR 2 is independently revertible.
+  - **Rejected:** one big PR (unreviewable); separate dev-sessions (over-ceremony for a coordinated sweep — sequenced as phases here instead).
+- **Decision:** Unify on `anyhow`, not `Box<dyn Error>`.
+  - **Why:** anyhow is already the majority convention and a dependency; gives `.context()` and cleaner signatures. Fits the "learning project, modernize" intent.
+  - **Rejected:** custom `thiserror` error enum (overkill for a CLI); status quo (the inconsistency is the thing being fixed).
+- **Decision:** `rustls-tls`, drop OpenSSL.
+  - **Why:** megalodon already pulls reqwest 0.12 + rustls (ring) and it builds on **every active CI musl target today** — so the half-remembered historical musl/ring blocker is already resolved for shipped targets. Removes the C/OpenSSL build dep and simplifies musl static builds.
+  - **Rejected:** keeping native-tls/openssl (perpetuates the dual stack and the vendored-C dependency). `i686-unknown-linux-musl` (the one target with a known `ring` failure) is already disabled in CI and stays out of scope.
+- **Decision:** Curated pedantic, not blanket.
+  - **Why:** `clippy::pedantic` is noisy; lints like `must_use_candidate`, `missing_errors_doc`, `missing_panics_doc`, `module_name_repetitions` add churn without value for a CLI. Enable the set, `allow` the noise deliberately, document why in the attribute block.
+  - **Rejected:** blanket-accept every pedantic lint (Les was tempted but chose curation).
+- **Decision:** TDD deferred; existing suite is the regression net.
+  - **Why:** this is refactoring with no intended behavior change. Broad coverage expansion is issue #60. Add tests only where an error path meaningfully changes or the new `util` module deserves direct coverage.
+
+## Patterns to follow
+
+- Target error convention: `use anyhow::{anyhow, Context, Result};` as already in `downloader.rs:1`, `importer.rs`, `db/activities.rs:1`; `anyhow!` usage at `instance.rs:105`, `importer.rs:53-60`.
+- Util module: model on the existing byte-identical `open_outfile_with_parent_dir` body (`themes.rs:75`), and the generic `copy_embedded_assets<Assets: RustEmbed>` shape (`site_generator.rs:59`) — promote that generic into `util`, delete the dead copy.
+- `?`-propagation and `??`-on-JoinHandle already work under anyhow (`fetcher.rs:143`, `cli/fetch.rs:118-119`) — keep.
+- reqwest call sites to migrate enumerated in `research.md` (§reqwest usage). Note `cli/mastodon/verify.rs:34` still has a `.build().unwrap()` — fix to `?` during the migration.
+
+## What we're NOT doing
+
+- **Not** fixing the correctness/security issues already filed: zip-slip #49, XSS #50, downloader failure-surfacing #51, TryFrom-for-untrusted-data #52, DB transactions #53, federated actor URLs #57, API-client timeouts #61. Idiom touches near this code must not silently absorb those fixes.
+- **Not** broadly expanding test coverage (#60) — only targeted tests per the TDD decision.
+- **Not** upgrading `warp` (its old hyper 0.14 / tungstenite 0.21 duplication remains — separate effort).
+- **Not** bumping `megalodon`, or the major-version-behind `config`/`env_logger`/`rusqlite`/`zip` (separate batched bump).
+- **Not** re-architecting the global config singleton (#55) or wiring the no-op `-v/-q/-d` flags (#58) — unless a pedantic lint forces a trivial local touch.
+- **Not** changing any user-visible CLI behavior, output, or on-disk formats.
+
+## Open questions
+
+- **Exact curated pedantic allow-list.** *Default:* enable `clippy::pedantic` + `clippy::nursery`, then `allow` at minimum `must_use_candidate`, `missing_errors_doc`, `missing_panics_doc`, `module_name_repetitions`, `missing_const_for_fn`; refine against actual output during PR 1 and record the final set in `notes.md`. Not blocking.
+- **Exact minimal tokio feature set.** *Default:* start from `["rt-multi-thread", "macros", "sync", "time"]` and let the compiler/CI (incl. Windows) dictate additions; record final set. Not blocking.
+- **Dockerfile libssl-dev / CI musl OpenSSL.** *Default:* remove `libssl-dev` from Dockerfile and any OpenSSL assumptions once `openssl` is dropped, gated on the full matrix passing; if any target regresses, keep the minimal necessary bits and note it. Not blocking.

--- a/src/activitystreams.rs
+++ b/src/activitystreams.rs
@@ -64,8 +64,7 @@ impl From<megalodon::entities::Attachment> for Attachment {
         let media_type = match attachment.r#type {
             AttachmentType::Audio => "audio/mp3",
             AttachmentType::Image => "image/png",
-            AttachmentType::Video => "video/mp4",
-            AttachmentType::Gifv => "video/mp4",
+            AttachmentType::Video | AttachmentType::Gifv => "video/mp4",
             AttachmentType::Unknown => "unknown",
         }
         .to_string();
@@ -94,7 +93,7 @@ pub struct Outbox<TItem: Serialize> {
     pub id: String,
     #[serde(rename = "type")]
     pub type_field: String,
-    pub total_items: i32,
+    pub total_items: u64,
     pub ordered_items: Vec<TItem>,
 }
 impl<TItem: Serialize> OrderedItems<TItem> for Outbox<TItem> {
@@ -109,7 +108,7 @@ pub struct OrderedCollection {
     pub id: String,
     #[serde(rename = "type")]
     pub type_field: String,
-    pub total_items: i32,
+    pub total_items: u64,
     pub first: String,
     pub last: String,
 }
@@ -243,7 +242,7 @@ impl From<megalodon::entities::Status> for Activity {
         let mut to = Vec::new();
         if let megalodon::entities::StatusVisibility::Public = status.visibility {
             to.push(PUBLIC_ID.to_string());
-        };
+        }
 
         // todo: better account for polls, retoots, etc?
         let activity_type_field = if status.reblog.is_some() {
@@ -271,10 +270,10 @@ impl From<megalodon::entities::Status> for Activity {
                                 type_field: "Note".to_string(),
                                 published: quoted_status.created_at,
                                 content: Some(quoted_status.content.clone()),
-                                summary: if !quoted_status.spoiler_text.is_empty() {
-                                    Some(quoted_status.spoiler_text.clone())
-                                } else {
+                                summary: if quoted_status.spoiler_text.is_empty() {
                                     None
+                                } else {
+                                    Some(quoted_status.spoiler_text.clone())
                                 },
                                 attachment: quoted_status
                                     .media_attachments
@@ -297,10 +296,10 @@ impl From<megalodon::entities::Status> for Activity {
                 type_field: "Note".to_string(),
                 published: status.created_at,
                 content: Some(status.content),
-                summary: if !status.spoiler_text.is_empty() {
-                    Some(status.spoiler_text)
-                } else {
+                summary: if status.spoiler_text.is_empty() {
                     None
+                } else {
+                    Some(status.spoiler_text)
                 },
                 attachment: status
                     .media_attachments
@@ -402,7 +401,7 @@ mod tests {
         include_str!("./resources/test/mastodon-status-with-attachment.json");
 
     #[test]
-    fn test_from_megalodon_status_to_activity() -> Result<()> {
+    fn test_from_megalodon_status_to_activity() {
         let status: megalodon::entities::Status =
             serde_json::from_str(JSON_MASTODON_STATUS_WITH_ATTACHMENT).unwrap();
         let activity: Activity = status.clone().into();
@@ -430,8 +429,6 @@ mod tests {
             chrono::DateTime::from_str("2023-07-16T22:02:21.535Z").unwrap();
         assert_eq!(activity.published, expected_published);
         assert_eq!(object.published, expected_published);
-
-        Ok(())
     }
 
     #[test]

--- a/src/activitystreams.rs
+++ b/src/activitystreams.rs
@@ -387,7 +387,7 @@ impl Attachments for Tag {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::error::Error;
+    use anyhow::Context;
     use std::path::Path;
     use std::str::FromStr;
     use test_log::test;
@@ -435,7 +435,7 @@ mod tests {
     }
 
     #[test]
-    fn test_remote_actor_attachments() -> Result<(), Box<dyn Error>> {
+    fn test_remote_actor_attachments() -> Result<()> {
         let actor: Actor = serde_json::from_str(JSON_REMOTE_ACTOR)?;
         let icon = actor.icon.as_ref().unwrap();
         let image = actor.image.as_ref().unwrap();
@@ -452,7 +452,7 @@ mod tests {
     }
 
     #[test]
-    fn test_activity_with_attachments() -> Result<(), Box<dyn Error>> {
+    fn test_activity_with_attachments() -> Result<()> {
         let actor: Actor = serde_json::from_str(JSON_REMOTE_ACTOR)?;
         let activity: Activity = serde_json::from_str(JSON_ACTIVITY_WITH_ATTACHMENT)?;
         let media_path = PathBuf::new().join("media");
@@ -479,19 +479,19 @@ mod tests {
     }
 
     #[test]
-    fn test_outbox_parsing_with_local_model() -> Result<(), Box<dyn Error>> {
+    fn test_outbox_parsing_with_local_model() -> Result<()> {
         let outbox: Outbox<Activity> = serde_json::from_str(JSON_OUTBOX)?;
 
         let ordered_items = outbox.ordered_items;
         assert!(!ordered_items.is_empty());
-        let item1 = ordered_items.first().ok_or("no item1")?;
+        let item1 = ordered_items.first().context("no item1")?;
         assert_eq!(
             item1.id,
             "https://mastodon.social/users/lmorchard/statuses/55864/activity"
         );
         assert_eq!(item1.type_field, "Create");
         assert_eq!(
-            item1.actor.id().ok_or("no actor id")?,
+            item1.actor.id().context("no actor id")?,
             "https://mastodon.social/users/lmorchard"
         );
 
@@ -499,7 +499,7 @@ mod tests {
     }
 
     #[test]
-    fn test_outbox_parsing_with_external_model() -> Result<(), Box<dyn Error>> {
+    fn test_outbox_parsing_with_external_model() -> Result<()> {
         let outbox: Outbox<activitystreams::activity::ActivityBox> =
             serde_json::from_str(JSON_OUTBOX)?;
 
@@ -510,7 +510,7 @@ mod tests {
         let item1: activitystreams::activity::Create = item1.clone().into_concrete()?;
 
         assert_eq!(
-            item1.object_props.id.ok_or("no id")?.as_str(),
+            item1.object_props.id.context("no id")?.as_str(),
             "https://mastodon.social/users/lmorchard/statuses/55864/activity"
         );
 
@@ -519,7 +519,7 @@ mod tests {
             item1
                 .create_props
                 .get_actor_xsd_any_uri()
-                .ok_or("no actor")?
+                .context("no actor")?
                 .as_str(),
             "https://mastodon.social/users/lmorchard"
         );
@@ -527,7 +527,7 @@ mod tests {
     }
 
     #[test]
-    fn test_activity_parsing_with_emoji() -> Result<(), Box<dyn Error>> {
+    fn test_activity_parsing_with_emoji() -> Result<()> {
         let activity: Activity = serde_json::from_str(JSON_ACTIVITY_WITH_EMOJI)?;
         assert_eq!(
             activity.id,

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,17 +1,17 @@
-use std::error::Error;
+use anyhow::Result;
 use std::path::Path;
 
 const DEFAULT_LOG_LEVEL: &str = "info";
 
 use crate::config;
 
-pub fn init(config_path: &Path) -> Result<(), Box<dyn Error>> {
+pub fn init(config_path: &Path) -> Result<()> {
     config::init(config_path)?;
     init_logging()?;
     Ok(())
 }
 
-pub fn init_logging() -> Result<(), Box<dyn Error>> {
+pub fn init_logging() -> Result<()> {
     let log_level = config::get::<String>("log_level").unwrap_or(DEFAULT_LOG_LEVEL.to_string());
     let log_env = env_logger::Env::default().default_filter_or(log_level);
     env_logger::Builder::from_env(log_env).init();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,5 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
-use std::convert::From;
-use std::error::Error;
 use std::path::{Path, PathBuf};
 
 use fossilizer::app;
@@ -51,7 +49,7 @@ enum Commands {
     Mastodon(mastodon::Args),
 }
 
-pub async fn execute() -> Result<(), Box<dyn Error>> {
+pub async fn execute() -> Result<()> {
     let cli = Cli::parse();
 
     let config_path = match cli.config.as_deref() {

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -33,14 +33,14 @@ pub async fn command(args: &BuildArgs) -> Result<()> {
 
     config::update(|config| {
         if let Some(theme) = &args.theme {
-            config.theme = theme.clone();
+            config.theme.clone_from(theme);
         }
     })?;
 
     let config = config::config()?;
     debug!("Using theme {:?}", config.theme);
 
-    site_generator::setup_build_path(&config.build_path, &clean)?;
+    site_generator::setup_build_path(&config.build_path, clean)?;
     media::ensure_build_media(&config.build_path, &config.media_path())?;
 
     if !skip_assets {

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use clap::Args;
 use fossilizer::{config, db, media, site_generator, templates};
-use std::error::Error;
 
 #[derive(Debug, Args)]
 pub struct BuildArgs {
@@ -25,7 +24,7 @@ pub struct BuildArgs {
     theme: Option<String>,
 }
 
-pub async fn command(args: &BuildArgs) -> Result<(), Box<dyn Error>> {
+pub async fn command(args: &BuildArgs) -> Result<()> {
     let clean = args.clean;
     let skip_index = args.skip_index;
     let skip_index_json = args.skip_index_json;

--- a/src/cli/import.rs
+++ b/src/cli/import.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use clap::Args;
 use std::convert::From;
-use std::error::Error;
 use std::fs;
 use std::path::PathBuf;
 
@@ -16,7 +15,7 @@ pub struct ImportArgs {
     skip_media: bool,
 }
 
-pub async fn command(args: &ImportArgs) -> Result<(), Box<dyn Error>> {
+pub async fn command(args: &ImportArgs) -> Result<()> {
     let config = config::config()?;
     let skip_media = args.skip_media;
 

--- a/src/cli/import.rs
+++ b/src/cli/import.rs
@@ -31,7 +31,7 @@ pub async fn command(args: &ImportArgs) -> Result<()> {
         let mut importer = mastodon::importer::Importer::new(conn, media_path, skip_media);
         let filename: PathBuf = filename.into();
         info!("Importing {:?}", filename);
-        importer.import(filename)?;
+        importer.import(&filename)?;
     }
     info!("Done");
 

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -14,7 +14,7 @@ pub struct InitArgs {
 }
 
 pub async fn command(args: &InitArgs) -> Result<()> {
-    site_generator::setup_data_path(&args.clean)?;
+    site_generator::setup_data_path(args.clean)?;
     db::upgrade()?;
     if args.customize {
         site_generator::unpack_customizable_resources()?;

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -1,8 +1,6 @@
 use anyhow::Result;
 use clap::Args;
 
-use std::error::Error;
-
 use fossilizer::{db, site_generator};
 
 #[derive(Debug, Args)]
@@ -15,7 +13,7 @@ pub struct InitArgs {
     customize: bool,
 }
 
-pub async fn command(args: &InitArgs) -> Result<(), Box<dyn Error>> {
+pub async fn command(args: &InitArgs) -> Result<()> {
     site_generator::setup_data_path(&args.clean)?;
     db::upgrade()?;
     if args.customize {

--- a/src/cli/mastodon.rs
+++ b/src/cli/mastodon.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use clap::Subcommand;
 use fossilizer::mastodon::instance::{load_instance_config, save_instance_config};
-use std::error::Error;
 
 mod code;
 mod fetch;
@@ -30,7 +29,7 @@ enum Commands {
     Fetch(fetch::FetchArgs),
 }
 
-pub async fn command(args: &Args) -> Result<(), Box<dyn Error>> {
+pub async fn command(args: &Args) -> Result<()> {
     let instance = args.instance.clone();
     let mut instance_config = load_instance_config(&instance)?;
     match &args.command {

--- a/src/cli/mastodon.rs
+++ b/src/cli/mastodon.rs
@@ -34,16 +34,16 @@ pub async fn command(args: &Args) -> Result<()> {
     let mut instance_config = load_instance_config(&instance)?;
     match &args.command {
         Commands::Link(subcommand_args) => {
-            link::command(subcommand_args, args, &mut instance_config).await?
+            link::command(subcommand_args, args, &mut instance_config).await?;
         }
         Commands::Code(subcommand_args) => {
-            code::command(subcommand_args, args, &mut instance_config).await?
+            code::command(subcommand_args, args, &mut instance_config).await?;
         }
         Commands::Verify(subcommand_args) => {
-            verify::command(subcommand_args, args, &mut instance_config).await?
+            verify::command(subcommand_args, args, &mut instance_config).await?;
         }
         Commands::Fetch(subcommand_args) => {
-            fetch::command(subcommand_args, args, &mut instance_config).await?
+            fetch::command(subcommand_args, args, &mut instance_config).await?;
         }
     }
     save_instance_config(&instance, &instance_config)?;

--- a/src/cli/mastodon/code.rs
+++ b/src/cli/mastodon/code.rs
@@ -1,10 +1,9 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 
 use crate::cli::mastodon::Args;
 use fossilizer::mastodon::{instance::InstanceConfig, OAUTH_SCOPES, REDIRECT_URI_OOB};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::error::Error;
 
 #[derive(Serialize, Deserialize, Debug)]
 struct CodeAuthResult {
@@ -23,12 +22,12 @@ pub async fn command(
     args: &CodeArgs,
     parent_args: &Args,
     instance_config: &mut InstanceConfig,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<()> {
     let instance = &parent_args.instance;
     let code = &args.code;
 
     let not_registered =
-        || format!("no client registered for {instance}; run `mastodon link` first");
+        || anyhow!("no client registered for {instance}; run `mastodon link` first");
     let client_id = instance_config
         .client_id
         .as_ref()
@@ -57,6 +56,6 @@ pub async fn command(
         info!("Authorization successful for {instance}");
         Ok(())
     } else {
-        Err(format!("failed to authorize with code: {}", res.status()).into())
+        Err(anyhow!("failed to authorize with code: {}", res.status()))
     }
 }

--- a/src/cli/mastodon/fetch.rs
+++ b/src/cli/mastodon/fetch.rs
@@ -2,8 +2,6 @@ use crate::cli::mastodon::Args;
 use anyhow::Result;
 use fossilizer::{db, mastodon::instance::InstanceConfig};
 
-use std::error::Error;
-
 use fossilizer::{config, mastodon::fetcher::Fetcher};
 
 #[derive(Debug, clap::Args)]
@@ -23,7 +21,7 @@ pub async fn command(
     args: &FetchArgs,
     parent_args: &Args,
     instance_config: &mut InstanceConfig,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<()> {
     let max = args.max;
     let page = args.page;
     let incremental: bool = args.incremental;

--- a/src/cli/mastodon/link.rs
+++ b/src/cli/mastodon/link.rs
@@ -4,7 +4,6 @@ use fossilizer::mastodon::{
     instance::{register_client_app, InstanceConfig},
     OAUTH_SCOPES, REDIRECT_URI_OOB,
 };
-use std::error::Error;
 
 #[derive(Debug, clap::Args)]
 pub struct LinkArgs {}
@@ -13,7 +12,7 @@ pub async fn command(
     _args: &LinkArgs,
     parent_args: &Args,
     instance_config: &mut InstanceConfig,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<()> {
     let instance = &parent_args.instance;
 
     if instance_config.client_id.is_none() {

--- a/src/cli/mastodon/verify.rs
+++ b/src/cli/mastodon/verify.rs
@@ -4,7 +4,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::cli::mastodon::Args;
 use fossilizer::mastodon::instance::InstanceConfig;
-use std::error::Error;
 
 #[derive(Serialize, Deserialize, Debug)]
 struct AuthVerifyResult {
@@ -21,7 +20,7 @@ pub async fn command(
     _args: &VerifyArgs,
     parent_args: &Args,
     instance_config: &mut InstanceConfig,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<()> {
     let instance = &parent_args.instance;
 
     if instance_config.access_token.is_none() {

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -28,7 +28,7 @@ pub async fn command(args: &ServeArgs) -> Result<()> {
         .parse()
         .map_err(|e| anyhow!("invalid host/port {addr:?}: {e}"))?;
 
-    let serving_url = format!("http://{}", addr);
+    let serving_url = format!("http://{addr}");
 
     info!("Serving up {} at {}", build_path.display(), serving_url);
 

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -1,7 +1,6 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use clap::Args;
 use fossilizer::config;
-use std::error::Error;
 use std::ffi::OsStr;
 use std::net::SocketAddr;
 
@@ -18,7 +17,7 @@ pub struct ServeArgs {
     open: bool,
 }
 
-pub async fn command(args: &ServeArgs) -> Result<(), Box<dyn Error>> {
+pub async fn command(args: &ServeArgs) -> Result<()> {
     let open_browser = args.open;
 
     let config = config::config()?;
@@ -27,7 +26,7 @@ pub async fn command(args: &ServeArgs) -> Result<(), Box<dyn Error>> {
     let addr = format!("{}:{}", args.host.clone(), args.port);
     let addr: SocketAddr = addr
         .parse()
-        .map_err(|e| format!("invalid host/port {addr:?}: {e}"))?;
+        .map_err(|e| anyhow!("invalid host/port {addr:?}: {e}"))?;
 
     let serving_url = format!("http://{}", addr);
 

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -1,12 +1,11 @@
 use anyhow::Result;
 use clap::Args;
 use fossilizer::db;
-use std::error::Error;
 
 #[derive(Debug, Args)]
 pub struct UpgradeArgs {}
 
-pub async fn command(_args: &UpgradeArgs) -> Result<(), Box<dyn Error>> {
+pub async fn command(_args: &UpgradeArgs) -> Result<()> {
     db::upgrade()?;
     Ok(())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
+use anyhow::{anyhow, Result};
 use config::Config;
 use dotenv;
 use serde::{Deserialize, Serialize};
-use std::error::Error;
 use std::path::{Path, PathBuf};
 use std::sync::RwLock;
 
@@ -70,7 +70,7 @@ impl AppConfig {
     }
 }
 
-pub fn init(config_path: &Path) -> Result<(), Box<dyn Error>> {
+pub fn init(config_path: &Path) -> Result<()> {
     dotenv::dotenv().ok();
 
     let mut config = Config::builder();
@@ -81,35 +81,47 @@ pub fn init(config_path: &Path) -> Result<(), Box<dyn Error>> {
 
     let config = config.build()?;
 
-    let mut context = CONTEXT.write()?;
+    let mut context = CONTEXT
+        .write()
+        .map_err(|e| anyhow!("config context lock poisoned: {e}"))?;
     context.raw_config = config.clone();
     context.config = config.try_deserialize()?;
 
     Ok(())
 }
 
-pub fn config() -> Result<AppConfig, Box<dyn Error>> {
-    Ok(CONTEXT.read()?.config.clone())
+pub fn config() -> Result<AppConfig> {
+    Ok(CONTEXT
+        .read()
+        .map_err(|e| anyhow!("config context lock poisoned: {e}"))?
+        .config
+        .clone())
 }
 
-pub fn update<U>(updater: U) -> Result<(), Box<dyn Error>>
+pub fn update<U>(updater: U) -> Result<()>
 where
     U: FnOnce(&mut AppConfig),
 {
-    let mut context = CONTEXT.write()?;
+    let mut context = CONTEXT
+        .write()
+        .map_err(|e| anyhow!("config context lock poisoned: {e}"))?;
     updater(&mut context.config);
     Ok(())
 }
 
-pub fn get<'de, T: Deserialize<'de>>(key: &str) -> Result<T, Box<dyn Error>> {
-    let context = CONTEXT.read()?;
+pub fn get<'de, T: Deserialize<'de>>(key: &str) -> Result<T> {
+    let context = CONTEXT
+        .read()
+        .map_err(|e| anyhow!("config context lock poisoned: {e}"))?;
     let value = context.raw_config.get::<T>(key)?;
     Ok(value)
 }
 
 /// Attempt to deserialize the entire configuration into the requested type.
-pub fn try_deserialize<'de, T: Deserialize<'de>>() -> Result<T, Box<dyn Error>> {
-    let context = CONTEXT.read()?;
+pub fn try_deserialize<'de, T: Deserialize<'de>>() -> Result<T> {
+    let context = CONTEXT
+        .read()
+        .map_err(|e| anyhow!("config context lock poisoned: {e}"))?;
     let config = context.raw_config.clone();
     let value = config.try_deserialize::<T>()?;
     Ok(value)

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,5 @@
 use anyhow::{anyhow, Result};
 use config::Config;
-use dotenv;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::sync::RwLock;
@@ -71,7 +70,7 @@ impl AppConfig {
 }
 
 pub fn init(config_path: &Path) -> Result<()> {
-    dotenv::dotenv().ok();
+    dotenvy::dotenv().ok();
 
     let mut config = Config::builder();
     if config_path.is_file() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,8 @@
+// `DEFAULT_CONFIG` binds to default_config.toml via include_str!; the template is
+// currently empty, so clippy::manual_string_new would collapse it to String::new()
+// and sever that binding. Scope the allow to this module rather than lose the link.
+#![allow(clippy::manual_string_new)]
+
 use anyhow::{anyhow, Result};
 use config::Config;
 use serde::{Deserialize, Serialize};

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,8 +1,7 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use lazy_static::lazy_static;
 use rusqlite::Connection;
 use rusqlite_migration::{Migrations, M};
-use std::error::Error;
 use std::fs;
 use std::path::Path;
 
@@ -27,11 +26,13 @@ lazy_static! {
     ]);
 }
 
-pub fn conn() -> Result<Connection, Box<dyn Error>> {
+pub fn conn() -> Result<Connection> {
     let config = config::config()?;
 
     let database_path = config.database_path();
-    let database_parent_path = Path::new(&database_path).parent().ok_or("no parent path")?;
+    let database_parent_path = Path::new(&database_path)
+        .parent()
+        .context("database path has no parent directory")?;
     fs::create_dir_all(database_parent_path)?;
 
     let conn = Connection::open(&database_path)?;
@@ -44,7 +45,7 @@ pub fn conn() -> Result<Connection, Box<dyn Error>> {
     Ok(conn)
 }
 
-pub fn upgrade() -> Result<(), Box<dyn Error>> {
+pub fn upgrade() -> Result<()> {
     let config = config::config()?;
 
     let mut conn = Connection::open(config.database_path())?;

--- a/src/db/activities.rs
+++ b/src/db/activities.rs
@@ -34,9 +34,9 @@ impl FromStr for ActivitySchema {
 impl std::fmt::Display for ActivitySchema {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ActivitySchema::Activity => write!(f, "{}", ACTIVITYSCHEMA_ACTIVITY),
-            ActivitySchema::Status => write!(f, "{}", ACTIVITYSCHEMA_STATUS),
-            ActivitySchema::Unknown(s) => write!(f, "{}", s),
+            ActivitySchema::Activity => write!(f, "{ACTIVITYSCHEMA_ACTIVITY}"),
+            ActivitySchema::Status => write!(f, "{ACTIVITYSCHEMA_STATUS}"),
+            ActivitySchema::Unknown(s) => write!(f, "{s}"),
         }
     }
 }
@@ -67,12 +67,12 @@ impl<'a> Activities<'a> {
         let schema = item.which_activity_schema().to_string();
         let json_text = serde_json::to_string_pretty(&item)?;
         let mut stmt = self.conn.prepare_cached(
-            r#"
+            r"
                 INSERT OR REPLACE INTO activities
                 (schema, json)
                 VALUES
                 (?1, ?2)                
-            "#,
+            ",
         )?;
         stmt.execute(params![schema, json_text])?;
 
@@ -134,12 +134,12 @@ impl<'a> Activities<'a> {
     pub fn get_published_years(&self) -> SingleColumnResult {
         query_single_column(
             self.conn,
-            r#"
+            r"
                 SELECT publishedYear
                 FROM activities
                 WHERE isPublic = 1
                 GROUP BY publishedYear
-            "#,
+            ",
             [],
         )
     }
@@ -147,12 +147,12 @@ impl<'a> Activities<'a> {
     pub fn get_published_months_for_year(&self, year: &String) -> SingleColumnResult {
         query_single_column(
             self.conn,
-            r#"
+            r"
                 SELECT publishedYearMonth
                 FROM activities
                 WHERE publishedYear = ? AND isPublic = 1
                 GROUP BY publishedYearMonth
-            "#,
+            ",
             [year],
         )
     }
@@ -160,12 +160,12 @@ impl<'a> Activities<'a> {
     pub fn get_published_days_for_month(&self, month: &String) -> SingleColumnResult {
         query_single_column(
             self.conn,
-            r#"
+            r"
                 SELECT publishedYearMonthDay
                 FROM activities
                 WHERE publishedYearMonth = ?1 AND isPublic = 1
                 GROUP BY publishedYearMonthDay
-            "#,
+            ",
             [month],
         )
     }
@@ -173,13 +173,13 @@ impl<'a> Activities<'a> {
     pub fn get_published_months(&self) -> SingleColumnResult {
         query_single_column(
             self.conn,
-            r#"
+            r"
                 SELECT publishedYearMonth
                 FROM activities
                 WHERE isPublic = 1
                 GROUP BY publishedYearMonth
                 ORDER BY publishedYearMonth
-            "#,
+            ",
             [],
         )
     }
@@ -187,13 +187,13 @@ impl<'a> Activities<'a> {
     pub fn get_published_days(&self) -> Result<Vec<(String, usize)>, rusqlite::Error> {
         let conn = self.conn;
         let mut stmt = conn.prepare_cached(
-            r#"
+            r"
                 SELECT publishedYearMonthDay, count(id)
                 FROM activities
                 WHERE isPublic = 1
                 GROUP BY publishedYearMonthDay
                 ORDER BY publishedYearMonthDay
-            "#,
+            ",
         )?;
         let res = stmt
             .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?
@@ -205,12 +205,12 @@ impl<'a> Activities<'a> {
     pub fn get_activities_for_day(&self, day: &String) -> Result<Vec<Activity>> {
         query_activities(
             self.conn,
-            r#"
+            r"
                 SELECT json, schema
                 FROM activities
                 WHERE publishedYearMonthDay = ?1 AND isPublic = 1
                 ORDER BY published ASC
-            "#,
+            ",
             [day],
         )
     }
@@ -218,12 +218,12 @@ impl<'a> Activities<'a> {
     pub fn get_activities_by_ids(&self, ids: &[String]) -> Result<Vec<Activity>> {
         query_activities(
             self.conn,
-            r#"
+            r"
                 SELECT json, schema
                 FROM activities
                 WHERE id IN rarray(?1)
                 ORDER BY published ASC
-            "#,
+            ",
             [ids_to_rarray_param(ids)],
         )
     }
@@ -231,11 +231,11 @@ impl<'a> Activities<'a> {
     pub fn count_activities_by_ids(&self, ids: &[String]) -> Result<i64> {
         query_count(
             self.conn,
-            r#"
+            r"
                 SELECT COUNT(id)
                 FROM activities
                 WHERE id IN rarray(?1)
-            "#,
+            ",
             [ids_to_rarray_param(ids)],
         )
     }
@@ -301,7 +301,7 @@ where
                             Err(e) => {
                                 warn!("Failed to deserialize upgraded Status: {}.", e);
                                 // Extract column number from error message if present
-                                let error_msg = format!("{}", e);
+                                let error_msg = format!("{e}");
                                 if let Some(col_str) = error_msg.split("column ").nth(1) {
                                     if let Some(col) = col_str
                                         .split_whitespace()
@@ -326,7 +326,7 @@ where
                         }
                     }
                 }
-                _ => Err(anyhow!("unknown schema {:?}", schema_str)),
+                ActivitySchema::Unknown(name) => Err(anyhow!("unknown schema {name:?}")),
             }
         })?
         .filter_map(|r| r.ok().flatten())

--- a/src/db/actors.rs
+++ b/src/db/actors.rs
@@ -2,7 +2,6 @@ use anyhow::Result;
 use rusqlite::{params, Connection};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::error::Error;
 
 use crate::activitystreams;
 
@@ -25,10 +24,7 @@ impl<'a> Actors<'a> {
         Ok(())
     }
 
-    pub fn get_actor<T: for<'de> Deserialize<'de>>(
-        &self,
-        id: &String,
-    ) -> Result<T, Box<dyn Error>> {
+    pub fn get_actor<T: for<'de> Deserialize<'de>>(&self, id: &String) -> Result<T> {
         let conn = &self.conn;
         let mut stmt = conn.prepare("SELECT json FROM actors WHERE id = ?")?;
         let json_text: String = stmt.query_row([id], |row| row.get(0))?;
@@ -54,9 +50,7 @@ impl<'a> Actors<'a> {
         Ok(out)
     }
 
-    pub fn get_actors_by_id(
-        &self,
-    ) -> Result<HashMap<String, activitystreams::Actor>, Box<dyn Error>> {
+    pub fn get_actors_by_id(&self) -> Result<HashMap<String, activitystreams::Actor>> {
         Ok(self
             .get_actors::<activitystreams::Actor>()?
             .into_iter()

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -121,10 +121,10 @@ impl Downloader {
                     _ = workers.join_next(), if !workers.is_empty() => {
                         trace!("Worker done - workers.len() = {}", workers.len());
                     }
-                    _ = new_task_notify.notified() => {
+                    () = new_task_notify.notified() => {
                         trace!("New task queued");
                     }
-                    _ = queue_closed.notified() => {
+                    () = queue_closed.notified() => {
                         trace!("Queue closed");
                         should_exit_when_empty = true;
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,8 @@
     clippy::unused_async,
     clippy::implicit_hasher,
     clippy::struct_excessive_bools,
-    clippy::non_std_lazy_statics
+    clippy::non_std_lazy_statics,
+    clippy::unnecessary_debug_formatting
 )]
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,16 @@
+#![warn(clippy::pedantic)]
+// Curated allow-list: lints that are noise for a CLI app rather than a library.
+#![allow(
+    clippy::must_use_candidate,
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::module_name_repetitions,
+    clippy::unused_async,
+    clippy::implicit_hasher,
+    clippy::struct_excessive_bools,
+    clippy::non_std_lazy_statics
+)]
+
 #[macro_use]
 extern crate lazy_static;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,3 +17,4 @@ pub mod media;
 pub mod site_generator;
 pub mod templates;
 pub mod themes;
+pub mod util;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,8 @@
     clippy::unused_async,
     clippy::implicit_hasher,
     clippy::struct_excessive_bools,
-    clippy::non_std_lazy_statics
+    clippy::non_std_lazy_statics,
+    clippy::unnecessary_debug_formatting
 )]
 
 mod cli;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,16 @@
+#![warn(clippy::pedantic)]
+// Curated allow-list: lints that are noise for a CLI app rather than a library.
+#![allow(
+    clippy::must_use_candidate,
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::module_name_repetitions,
+    clippy::unused_async,
+    clippy::implicit_hasher,
+    clippy::struct_excessive_bools,
+    clippy::non_std_lazy_statics
+)]
+
 mod cli;
 
 #[macro_use]

--- a/src/mastodon/importer.rs
+++ b/src/mastodon/importer.rs
@@ -13,7 +13,7 @@ use std::fs;
 use std::fs::File;
 
 use std::io::{copy, Read};
-use std::path::{Component, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use tar::Archive;
 use walkdir::WalkDir;
 
@@ -43,8 +43,7 @@ impl Importer {
         }
     }
 
-    pub fn import(&mut self, filepath: PathBuf) -> Result<()> {
-        let filepath = filepath.as_path();
+    pub fn import(&mut self, filepath: &Path) -> Result<()> {
         let file = File::open(filepath)?;
 
         // todo: do something with filemagic here to auto-detect archive format based on file contents?
@@ -58,7 +57,7 @@ impl Importer {
             "tar" => self.import_tar(file, false)?,
             "zip" => self.import_zip(file)?,
             other => return Err(anyhow!("unsupported archive format: {other}")),
-        };
+        }
 
         Ok(())
     }
@@ -185,7 +184,7 @@ impl Importer {
 
             for entry in WalkDir::new(&temp_media_path)
                 .into_iter()
-                .filter_map(|e| e.ok())
+                .filter_map(std::result::Result::ok)
             {
                 if !entry.file_type().is_file() {
                     continue;

--- a/src/mastodon/instance.rs
+++ b/src/mastodon/instance.rs
@@ -5,7 +5,6 @@ use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use std::error::Error;
 use std::fs;
 
 use std::io::prelude::*;
@@ -32,14 +31,14 @@ impl InstanceConfig {
     }
 }
 
-fn build_instance_config_path(instance: &String) -> Result<PathBuf, Box<dyn Error>> {
+fn build_instance_config_path(instance: &String) -> Result<PathBuf> {
     let config = config::config()?;
     let data_path = config.data_path;
     // todo: hash the instance domain string rather than using it verbatim?
     Ok(data_path.join(format!("config-instance-{instance}.toml")))
 }
 
-pub fn load_instance_config(instance: &String) -> Result<InstanceConfig, Box<dyn Error>> {
+pub fn load_instance_config(instance: &String) -> Result<InstanceConfig> {
     let config_path = build_instance_config_path(instance)?;
     trace!(
         "Loading {} instance config file from {:?}",
@@ -54,10 +53,7 @@ pub fn load_instance_config(instance: &String) -> Result<InstanceConfig, Box<dyn
     }
 }
 
-pub fn save_instance_config(
-    instance: &String,
-    instance_config: &InstanceConfig,
-) -> Result<(), Box<dyn Error>> {
+pub fn save_instance_config(instance: &String, instance_config: &InstanceConfig) -> Result<()> {
     let config_path = build_instance_config_path(instance)?;
     trace!(
         "Saving {} instance config file to {:?}",

--- a/src/media.rs
+++ b/src/media.rs
@@ -1,4 +1,4 @@
-use std::error::Error;
+use anyhow::{anyhow, Result};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -15,7 +15,7 @@ use std::path::{Path, PathBuf};
 ///   returns an error rather than risk clobbering.
 /// - If symlink creation is unsupported/fails, copies `media_path` into
 ///   `build_path/media` and warns (non-fatal).
-pub fn ensure_build_media(build_path: &Path, media_path: &Path) -> Result<(), Box<dyn Error>> {
+pub fn ensure_build_media(build_path: &Path, media_path: &Path) -> Result<()> {
     fs::create_dir_all(build_path)?;
     let link = build_path.join("media");
     let media_target = absolutize(media_path)?;
@@ -35,12 +35,11 @@ pub fn ensure_build_media(build_path: &Path, media_path: &Path) -> Result<(), Bo
             let legacy_nonempty = dir_has_entries(&link)?;
             let media_nonempty = media_existed && dir_has_entries(media_path)?;
             if legacy_nonempty && media_nonempty {
-                return Err(format!(
+                return Err(anyhow!(
                     "both {link:?} (legacy media directory) and {media_path:?} contain \
                      media; refusing to migrate automatically. Merge them into \
                      {media_path:?}, remove {link:?}, then re-run."
-                )
-                .into());
+                ));
             }
             if legacy_nonempty {
                 // Promote the legacy dir to become the media store. An empty
@@ -59,14 +58,13 @@ pub fn ensure_build_media(build_path: &Path, media_path: &Path) -> Result<(), Bo
             }
         }
         Ok(_) => {
-            return Err(format!(
+            return Err(anyhow!(
                 "{link:?} exists but is neither a directory nor a symlink; \
                  remove it and re-run."
-            )
-            .into());
+            ));
         }
         Err(ref e) if e.kind() == std::io::ErrorKind::NotFound => {}
-        Err(e) => return Err(Box::new(e)),
+        Err(e) => return Err(e.into()),
     }
 
     fs::create_dir_all(media_path)?;
@@ -82,7 +80,7 @@ pub fn ensure_build_media(build_path: &Path, media_path: &Path) -> Result<(), Bo
     Ok(())
 }
 
-fn absolutize(p: &Path) -> Result<PathBuf, Box<dyn Error>> {
+fn absolutize(p: &Path) -> Result<PathBuf> {
     if p.is_absolute() {
         Ok(p.to_path_buf())
     } else {
@@ -90,11 +88,11 @@ fn absolutize(p: &Path) -> Result<PathBuf, Box<dyn Error>> {
     }
 }
 
-fn dir_has_entries(p: &Path) -> Result<bool, Box<dyn Error>> {
+fn dir_has_entries(p: &Path) -> Result<bool> {
     Ok(fs::read_dir(p)?.next().is_some())
 }
 
-fn copy_dir_contents(from: &Path, to: &Path) -> Result<(), Box<dyn Error>> {
+fn copy_dir_contents(from: &Path, to: &Path) -> Result<()> {
     let opts = fs_extra::dir::CopyOptions {
         overwrite: true,
         content_only: true,
@@ -106,7 +104,7 @@ fn copy_dir_contents(from: &Path, to: &Path) -> Result<(), Box<dyn Error>> {
 
 /// Move a directory, falling back to copy-then-remove when a plain rename is
 /// not possible (e.g. `EXDEV` across filesystems).
-fn move_dir(from: &Path, to: &Path) -> Result<(), Box<dyn Error>> {
+fn move_dir(from: &Path, to: &Path) -> Result<()> {
     match fs::rename(from, to) {
         Ok(()) => Ok(()),
         // A plain rename only fails to cross filesystems with `CrossesDevices`
@@ -114,11 +112,11 @@ fn move_dir(from: &Path, to: &Path) -> Result<(), Box<dyn Error>> {
         // error (permissions, unexpected state) is real — surface it rather than
         // masking it behind a copy.
         Err(e) if e.kind() == std::io::ErrorKind::CrossesDevices => copy_dir_across(from, to),
-        Err(e) => Err(Box::new(e)),
+        Err(e) => Err(e.into()),
     }
 }
 
-fn copy_dir_across(from: &Path, to: &Path) -> Result<(), Box<dyn Error>> {
+fn copy_dir_across(from: &Path, to: &Path) -> Result<()> {
     if let Some(parent) = to.parent() {
         fs::create_dir_all(parent)?;
     }
@@ -290,7 +288,7 @@ mod tests {
         assert!(build.join("media").join("important.bin").exists());
 
         // Run the real clean routine used by `build --clean`.
-        crate::site_generator::setup_build_path(&build, &true).unwrap();
+        crate::site_generator::setup_build_path(&build, true).unwrap();
 
         // The build dir was wiped, but the media store MUST survive.
         assert!(

--- a/src/site_generator.rs
+++ b/src/site_generator.rs
@@ -2,22 +2,20 @@ use crate::config::DEFAULT_CONFIG;
 use crate::templates::contexts;
 use crate::themes::{copy_embedded_themes, copy_embedded_web_assets};
 use crate::{activitystreams, config, db, templates, util};
-use anyhow::Result;
+use anyhow::{Context, Result};
 use rayon::prelude::*;
 use std::collections::HashMap;
-use std::error::Error;
 use std::fs;
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 use tera::Tera;
 
-pub fn setup_build_path(build_path: &PathBuf, clean: &bool) -> Result<(), Box<dyn Error>> {
+pub fn setup_build_path(build_path: &PathBuf, clean: &bool) -> Result<()> {
     if *clean {
         info!("Cleaning build path");
         if let Err(err) = fs::remove_dir_all(build_path) {
             if err.kind() != std::io::ErrorKind::NotFound {
-                // todo: improve error handling here
-                return Err(Box::new(err));
+                return Err(err.into());
             }
         }
     }
@@ -25,7 +23,7 @@ pub fn setup_build_path(build_path: &PathBuf, clean: &bool) -> Result<(), Box<dy
     Ok(())
 }
 
-pub fn setup_data_path(clean: &bool) -> Result<(), Box<dyn Error>> {
+pub fn setup_data_path(clean: &bool) -> Result<()> {
     let config = config::config()?;
     let data_path = &config.data_path;
 
@@ -33,8 +31,7 @@ pub fn setup_data_path(clean: &bool) -> Result<(), Box<dyn Error>> {
         info!("Cleaning data path");
         if let Err(err) = fs::remove_dir_all(data_path) {
             if err.kind() != std::io::ErrorKind::NotFound {
-                // todo: improve error handling here
-                return Err(Box::new(err));
+                return Err(err.into());
             }
         }
     }
@@ -43,7 +40,7 @@ pub fn setup_data_path(clean: &bool) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-pub fn unpack_customizable_resources() -> Result<(), Box<dyn Error>> {
+pub fn unpack_customizable_resources() -> Result<()> {
     let config = config::config()?;
 
     let mut config_outfile = util::open_outfile_with_parent_dir(&config.config_path())?;
@@ -54,7 +51,7 @@ pub fn unpack_customizable_resources() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-pub fn copy_web_assets(build_path: &PathBuf) -> Result<(), Box<dyn Error>> {
+pub fn copy_web_assets(build_path: &PathBuf) -> Result<()> {
     let config = config::config()?;
 
     let web_assets_path = config.web_assets_path();
@@ -72,7 +69,7 @@ pub fn copy_web_assets(build_path: &PathBuf) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-pub fn copy_files<P>(media_path: &[P], build_path: &P) -> Result<(), Box<dyn Error>>
+pub fn copy_files<P>(media_path: &[P], build_path: &P) -> Result<()>
 where
     P: AsRef<Path> + std::fmt::Debug,
 {
@@ -102,7 +99,7 @@ where
 pub fn plan_activities_pages(
     build_path: &PathBuf,
     db_activities: &db::activities::Activities<'_>,
-) -> Result<Vec<contexts::IndexDayContext>, Box<dyn Error>> {
+) -> Result<Vec<contexts::IndexDayContext>> {
     let mut entries: Vec<contexts::IndexDayContext> = Vec::new();
     let all_days = db_activities.get_published_days()?;
     for (date, count) in all_days {
@@ -131,7 +128,7 @@ pub fn generate_activities_pages(
     tera: &Tera,
     actors: &HashMap<String, activitystreams::Actor>,
     day_entries: &Vec<contexts::IndexDayContext>,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<()> {
     info!("Generating {} per-day pages", day_entries.len());
     day_entries
         .par_iter()
@@ -144,7 +141,7 @@ pub fn generate_activity_page(
     tera: &Tera,
     actors: &HashMap<String, activitystreams::Actor>,
     day_entry: &contexts::IndexDayContext,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<()> {
     // let tera = templates::init()?;
     let db_conn = db::conn()?;
     let db_activities = db::activities::Activities::new(&db_conn);
@@ -189,7 +186,7 @@ pub fn generate_index_page(
     build_path: &PathBuf,
     day_entries: &Vec<contexts::IndexDayContext>,
     tera: &tera::Tera,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<()> {
     info!("Generating site index page");
 
     let index_path = PathBuf::from(&build_path)
@@ -212,7 +209,7 @@ pub fn generate_index_page(
 pub fn generate_index_json(
     build_path: &PathBuf,
     day_entries: &Vec<contexts::IndexDayContext>,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<()> {
     info!("Generating site index JSON");
 
     let file_path = PathBuf::from(&build_path)
@@ -221,7 +218,7 @@ pub fn generate_index_json(
 
     let output = serde_json::to_string_pretty(&day_entries)?;
 
-    let file_parent_path = file_path.parent().ok_or("no parent path")?;
+    let file_parent_path = file_path.parent().context("no parent path")?;
     fs::create_dir_all(file_parent_path)?;
 
     let mut file = fs::File::create(file_path)?;

--- a/src/site_generator.rs
+++ b/src/site_generator.rs
@@ -10,8 +10,8 @@ use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 use tera::Tera;
 
-pub fn setup_build_path(build_path: &PathBuf, clean: &bool) -> Result<()> {
-    if *clean {
+pub fn setup_build_path(build_path: &PathBuf, clean: bool) -> Result<()> {
+    if clean {
         info!("Cleaning build path");
         if let Err(err) = fs::remove_dir_all(build_path) {
             if err.kind() != std::io::ErrorKind::NotFound {
@@ -23,11 +23,11 @@ pub fn setup_build_path(build_path: &PathBuf, clean: &bool) -> Result<()> {
     Ok(())
 }
 
-pub fn setup_data_path(clean: &bool) -> Result<()> {
+pub fn setup_data_path(clean: bool) -> Result<()> {
     let config = config::config()?;
     let data_path = &config.data_path;
 
-    if *clean {
+    if clean {
         info!("Cleaning data path");
         if let Err(err) = fs::remove_dir_all(data_path) {
             if err.kind() != std::io::ErrorKind::NotFound {

--- a/src/site_generator.rs
+++ b/src/site_generator.rs
@@ -1,10 +1,9 @@
 use crate::config::DEFAULT_CONFIG;
 use crate::templates::contexts;
 use crate::themes::{copy_embedded_themes, copy_embedded_web_assets};
-use crate::{activitystreams, config, db, templates};
+use crate::{activitystreams, config, db, templates, util};
 use anyhow::Result;
 use rayon::prelude::*;
-use rust_embed::RustEmbed;
 use std::collections::HashMap;
 use std::error::Error;
 use std::fs;
@@ -47,35 +46,12 @@ pub fn setup_data_path(clean: &bool) -> Result<(), Box<dyn Error>> {
 pub fn unpack_customizable_resources() -> Result<(), Box<dyn Error>> {
     let config = config::config()?;
 
-    let mut config_outfile = open_outfile_with_parent_dir(&config.config_path())?;
+    let mut config_outfile = util::open_outfile_with_parent_dir(&config.config_path())?;
     config_outfile.write_all(DEFAULT_CONFIG.as_bytes())?;
 
     copy_embedded_themes(&config.themes_path())?;
 
     Ok(())
-}
-
-// todo: move this to a shared utils module? build.rs also uses
-pub fn copy_embedded_assets<Assets: RustEmbed>(
-    assets_output_path: &PathBuf,
-) -> Result<(), Box<dyn Error>> {
-    for filename in Assets::iter() {
-        let file = Assets::get(&filename).ok_or("no asset")?;
-        let outpath = PathBuf::from(&assets_output_path).join(filename.to_string());
-
-        let mut outfile = open_outfile_with_parent_dir(&outpath)?;
-        outfile.write_all(file.data.as_ref())?;
-
-        debug!("Wrote {} to {:?}", filename, outpath);
-    }
-    Ok(())
-}
-
-pub fn open_outfile_with_parent_dir(outpath: &PathBuf) -> Result<fs::File, Box<dyn Error>> {
-    let outparent = outpath.parent().ok_or("no parent path")?;
-    fs::create_dir_all(outparent)?;
-    let outfile = fs::File::create(outpath)?;
-    Ok(outfile)
 }
 
 pub fn copy_web_assets(build_path: &PathBuf) -> Result<(), Box<dyn Error>> {

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1,7 +1,7 @@
+use anyhow::{Context, Result};
 use serde::Serialize;
 use serde_json::value::{to_value, Value};
 use std::collections::HashMap;
-use std::error::Error;
 use std::fs;
 use std::io::prelude::*;
 use std::path::PathBuf;
@@ -13,7 +13,7 @@ use crate::themes::templates_source;
 
 pub mod contexts;
 
-pub fn init() -> Result<Tera, Box<dyn Error>> {
+pub fn init() -> Result<Tera> {
     let config = config::config()?;
 
     let mut tera: Tera;
@@ -24,7 +24,7 @@ pub fn init() -> Result<Tera, Box<dyn Error>> {
         tera = Tera::new(
             templates_glob
                 .to_str()
-                .ok_or("failed to construct templates glob")?,
+                .context("failed to construct templates glob")?,
         )?;
     } else {
         debug!("Using embedded templates");
@@ -60,8 +60,8 @@ pub fn render_to_file(
     file_path: &PathBuf,
     template_name: &str,
     context: impl Serialize,
-) -> Result<(), Box<dyn Error>> {
-    let file_parent_path = file_path.parent().ok_or("no parent path")?;
+) -> Result<()> {
+    let file_parent_path = file_path.parent().context("no parent path")?;
     fs::create_dir_all(file_parent_path)?;
     let context = tera::Context::from_serialize(context)?;
     let output = tera.render(template_name, &context)?;
@@ -85,7 +85,7 @@ mod tests {
     const JSON_ACTOR: &str = include_str!("./resources/test/actor.json");
 
     #[test]
-    fn test_activity_template_with_attachment() -> Result<(), Box<dyn Error>> {
+    fn test_activity_template_with_attachment() -> Result<()> {
         config::init(&Path::new("./resources/default_config.toml"))?;
         let tera = init()?;
 

--- a/src/templates/contexts.rs
+++ b/src/templates/contexts.rs
@@ -46,7 +46,7 @@ pub struct IndexDayEntry {
     pub count: usize,
 }
 
-/// Calendar of [`IndexDayContext`] structs, organized by into nested [`HashMap`]s
+/// Calendar of [`IndexDayContext`] structs, organized into nested [`HashMap`]s
 /// indexed by year, month, and day.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CalendarContext(HashMap<String, HashMap<String, HashMap<String, IndexDayContext>>>);

--- a/src/templates/contexts.rs
+++ b/src/templates/contexts.rs
@@ -12,7 +12,7 @@ use crate::activitystreams;
 pub struct IndexTemplateContext {
     /// Relative path to the site root from the current page
     pub site_root: String,
-    /// Calendar of nested hashmaps, organizing [IndexDayContext]s by year, month, and day
+    /// Calendar of nested hashmaps, organizing [`IndexDayContext`]s by year, month, and day
     pub calendar: CalendarContext,
 }
 
@@ -46,7 +46,7 @@ pub struct IndexDayEntry {
     pub count: usize,
 }
 
-/// Calendar of [IndexDayContext] structs, organized by into nested [HashMap]s
+/// Calendar of [`IndexDayContext`] structs, organized by into nested [`HashMap`]s
 /// indexed by year, month, and day.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CalendarContext(HashMap<String, HashMap<String, HashMap<String, IndexDayContext>>>);
@@ -56,7 +56,7 @@ impl CalendarContext {
         CalendarContext(HashMap::new())
     }
 
-    /// Insert an [IndexDayContext] into the [CalendarContext], using
+    /// Insert an [`IndexDayContext`] into the [`CalendarContext`], using
     /// year / month / day keys based on the date property
     pub fn insert(&mut self, day_context: &IndexDayContext) {
         let calendar = &mut self.0;
@@ -88,7 +88,7 @@ impl Default for CalendarContext {
     }
 }
 impl From<&Vec<IndexDayContext>> for CalendarContext {
-    /// Produce a [CalendarContext] from a [`Vec<IndexDayContext>`]
+    /// Produce a [`CalendarContext`] from a [`Vec<IndexDayContext>`]
     fn from(value: &Vec<IndexDayContext>) -> Self {
         let mut calendar = Self::new();
         for entry in value {

--- a/src/themes.rs
+++ b/src/themes.rs
@@ -1,52 +1,23 @@
+use crate::util;
 use rust_embed::RustEmbed;
 use std::error::Error;
-use std::fs;
-use std::io::prelude::*;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(RustEmbed)]
 #[folder = "src/resources/themes"]
 pub struct ThemeAsset;
 
-pub fn copy_embedded_themes(assets_output_path: &PathBuf) -> Result<(), Box<dyn Error>> {
-    for filename in ThemeAsset::iter() {
-        let file = ThemeAsset::get(&filename).ok_or("no asset")?;
-        let outpath = PathBuf::from(&assets_output_path).join(filename.to_string());
-
-        let mut outfile = open_outfile_with_parent_dir(&outpath)?;
-        outfile.write_all(file.data.as_ref())?;
-
-        debug!("Wrote {} to {:?}", filename, outpath);
-    }
+pub fn copy_embedded_themes(assets_output_path: &Path) -> Result<(), Box<dyn Error>> {
+    util::copy_embedded_assets::<ThemeAsset>(assets_output_path, None)?;
     Ok(())
 }
 
 pub fn copy_embedded_web_assets(
     theme_prefix: &str,
-    assets_output_path: &PathBuf,
+    assets_output_path: &Path,
 ) -> Result<(), Box<dyn Error>> {
-    let prefix = PathBuf::from(&theme_prefix)
-        .join("web")
-        .to_string_lossy()
-        .into_owned();
-    for filename in ThemeAsset::iter() {
-        if !filename.to_string().starts_with(&prefix) {
-            continue;
-        }
-        // FIXME: this is all pretty ugly - can be done better?
-        let local_path = PathBuf::from(filename.to_string())
-            .strip_prefix(&prefix)
-            .unwrap()
-            .to_string_lossy()
-            .into_owned();
-        let file = ThemeAsset::get(&filename).ok_or("no asset")?;
-        let outpath = PathBuf::from(&assets_output_path).join(&local_path);
-
-        let mut outfile = open_outfile_with_parent_dir(&outpath)?;
-        outfile.write_all(file.data.as_ref())?;
-
-        debug!("Wrote {} to {:?}", filename, outpath);
-    }
+    let prefix = format!("{theme_prefix}/web");
+    util::copy_embedded_assets::<ThemeAsset>(assets_output_path, Some(&prefix))?;
     Ok(())
 }
 
@@ -70,11 +41,4 @@ pub fn templates_source(theme_prefix: &str) -> Vec<(String, String)> {
             (local_path, file)
         })
         .collect::<Vec<(String, String)>>()
-}
-
-pub fn open_outfile_with_parent_dir(outpath: &PathBuf) -> Result<fs::File, Box<dyn Error>> {
-    let outparent = outpath.parent().ok_or("no parent path")?;
-    fs::create_dir_all(outparent)?;
-    let outfile = fs::File::create(outpath)?;
-    Ok(outfile)
 }

--- a/src/themes.rs
+++ b/src/themes.rs
@@ -1,21 +1,18 @@
 use crate::util;
+use anyhow::Result;
 use rust_embed::RustEmbed;
-use std::error::Error;
 use std::path::{Path, PathBuf};
 
 #[derive(RustEmbed)]
 #[folder = "src/resources/themes"]
 pub struct ThemeAsset;
 
-pub fn copy_embedded_themes(assets_output_path: &Path) -> Result<(), Box<dyn Error>> {
+pub fn copy_embedded_themes(assets_output_path: &Path) -> Result<()> {
     util::copy_embedded_assets::<ThemeAsset>(assets_output_path, None)?;
     Ok(())
 }
 
-pub fn copy_embedded_web_assets(
-    theme_prefix: &str,
-    assets_output_path: &Path,
-) -> Result<(), Box<dyn Error>> {
+pub fn copy_embedded_web_assets(theme_prefix: &str, assets_output_path: &Path) -> Result<()> {
     let prefix = format!("{theme_prefix}/web");
     util::copy_embedded_assets::<ThemeAsset>(assets_output_path, Some(&prefix))?;
     Ok(())

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,61 @@
+use anyhow::{anyhow, Result};
+use rust_embed::RustEmbed;
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+/// Create the parent directory (if needed) and open `outpath` for writing.
+pub fn open_outfile_with_parent_dir(outpath: &Path) -> Result<fs::File> {
+    let outparent = outpath
+        .parent()
+        .ok_or_else(|| anyhow!("no parent path for {}", outpath.display()))?;
+    fs::create_dir_all(outparent)?;
+    Ok(fs::File::create(outpath)?)
+}
+
+/// Copy every embedded asset from a `RustEmbed` folder into `output_path`.
+///
+/// If `strip_prefix` is set, only assets whose path begins with that prefix are
+/// copied, and the prefix is removed from their output path. When it is `None`,
+/// every asset is copied preserving its embedded path.
+pub fn copy_embedded_assets<Assets: RustEmbed>(
+    output_path: &Path,
+    strip_prefix: Option<&str>,
+) -> Result<()> {
+    for filename in Assets::iter() {
+        let name = filename.as_ref();
+        let rel = match strip_prefix {
+            Some(prefix) => match Path::new(name).strip_prefix(prefix) {
+                Ok(rel) => rel.to_path_buf(),
+                Err(_) => continue,
+            },
+            None => Path::new(name).to_path_buf(),
+        };
+        let asset = Assets::get(name).ok_or_else(|| anyhow!("missing embedded asset {name}"))?;
+        let outpath = output_path.join(rel);
+
+        let mut outfile = open_outfile_with_parent_dir(&outpath)?;
+        outfile.write_all(asset.data.as_ref())?;
+
+        debug!("Wrote {name} to {}", outpath.display());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_outfile_creates_missing_parent_dirs() {
+        let dir = std::env::temp_dir().join(format!("fossilizer-util-{}", std::process::id()));
+        let target = dir.join("a/b/c.txt");
+        let _ = fs::remove_dir_all(&dir);
+
+        let mut f = open_outfile_with_parent_dir(&target).unwrap();
+        f.write_all(b"ok").unwrap();
+
+        assert_eq!(fs::read_to_string(&target).unwrap(), "ok");
+        fs::remove_dir_all(&dir).unwrap();
+    }
+}


### PR DESCRIPTION
## Summary

**PR 1 of 2** in the Rust modernization sweep (dev-session `2026-07-23-1637-rust-modernization`). This is the **non-behavioral idiom polish** half; PR 2 (reqwest 0.12 / rustls / drop OpenSSL / tokio feature trim) follows separately as the behavioral dep/TLS change.

No behavior change. Verified: `cargo fmt --all -- --check` ✅ · `cargo clippy --all-targets --locked -- -D warnings` ✅ (with `clippy::pedantic` enabled) · `cargo test` ✅ (24 tests).

Kept as **4 phase commits + 1 integration commit** (not squashed) so each step reviews independently.

## What's in it

**Phase 1 — extract `util` module** (`582949b`): dedupe the byte-identical `open_outfile_with_parent_dir`, promote the (dead, uncalled) generic `copy_embedded_assets` into `util` with an optional strip-prefix so both theme-copy paths delegate to it; add a unit test.

**Phase 2 — unify on `anyhow::Result`** (`daf85d5`): replace `Result<_, Box<dyn Error>>` across all compiled modules (~30 signatures), drop redundant `use std::error::Error`. Notable conversions: `RwLock` `PoisonError` (`!Send`, can't go through anyhow's `?`) → explicit `.map_err(|e| anyhow!(...))`; `.ok_or("str")?` → `.context(...)`; `format!(..).into()` → `anyhow!`.

**Phase 3 — `dotenv` → `dotenvy`** (`60c83b3`): swap the unmaintained crate for its maintained fork.

**Phase 4 — curated `clippy::pedantic`** (`f5719dc`): `#![warn(clippy::pedantic)]` in both crate roots with a documented `#![allow(...)]` for lints that are noise in a CLI app (see commit + `notes.md`). Fixes the flagged idioms (inline format args, merged match arms, `Importer::import(PathBuf)`→`&Path`, `clone_from`, `&bool`→`bool`, `total_items: i32`→`u64`, …).

**Integration** (`a05af38`): PR #62 (media-in-data-dir) merged mid-session; conform the new `src/media.rs` to the same anyhow + pedantic conventions.

## Deliberately deferred (see `notes.md`)
- Broad `&String`/`&PathBuf`/`&Vec` → `&str`/`&Path`/`&[T]` sweep — **not** flagged even under pedantic (shielded by forwarding to owned-ref-taking fns); forcing it risks a cascade with no lint backing. Left as an optional focused follow-up.
- `lazy_static!` → `std::sync::LazyLock` — a dep-graph change, deferred to PR 2.

## Note for the reviewer
While migrating I found `src/resources/default_config.toml` is **empty (0 bytes)** and has been since it was added, so `init` writes an empty `config.toml`. That looks like a latent pre-existing bug — out of scope here (I kept the `include_str!` binding via a scoped `#[allow]`), but worth its own issue.

## References
- Spec/plan/notes: `docs/dev-sessions/2026-07-23-1637-rust-modernization/`
- Advances #58 (error-type unification, utils extraction, dead-code removal). Relates to #54/#60 (addressed in PR 2 / deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
